### PR TITLE
Fix dockhand_environment agent_token drift for agent-standard (Fixes #2)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+- 
+
+## Linked Issue
+
+<!-- Required for bugfix/feature work. Example: Fixes #123 -->
+Fixes #
+
+## Validation
+
+- [ ] `go test ./...`
+- [ ] Acceptance tests (if applicable)
+
+## Release Notes
+
+- [ ] User-facing behavior changed
+- [ ] No user-facing behavior change

--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -1,0 +1,102 @@
+name: PR Issue Link
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Require linked issue and mark in-progress
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate closing reference and label linked issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const action = context.payload.action;
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
+            const closeRegex = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
+            const linked = new Set();
+            let match;
+            while ((match = closeRegex.exec(body)) !== null) {
+              linked.add(Number(match[1]));
+            }
+
+            if (linked.size === 0 && action !== "closed") {
+              core.setFailed(
+                "PR description must include a closing reference (example: `Fixes #123`)."
+              );
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const ensureLabel = async (name, color, description) => {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status === 404) {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name,
+                    color,
+                    description,
+                  });
+                } else {
+                  throw error;
+                }
+              }
+            };
+
+            if (action === "closed") {
+              if (linked.size === 0) {
+                return;
+              }
+
+              await ensureLabel("awaiting-release", "FBCA04", "Issue fixed on main and waiting for a tagged release");
+
+              for (const issueNumber of linked) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    name: "in-progress",
+                  });
+                } catch (error) {
+                  if (error.status !== 404) {
+                    throw error;
+                  }
+                }
+
+                if (pr.merged) {
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    labels: ["awaiting-release"],
+                  });
+                }
+              }
+              return;
+            }
+
+            // Ensure "in-progress" label exists once.
+            await ensureLabel("in-progress", "1D76DB", "Issue is linked to an open pull request");
+
+            for (const issueNumber of linked) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                labels: ["in-progress"],
+              });
+            }

--- a/.github/workflows/release-issue-notify.yml
+++ b/.github/workflows/release-issue-notify.yml
@@ -1,0 +1,128 @@
+name: Release Issue Notify
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  notify:
+    name: Comment released issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment linked issues with release version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const release = context.payload.release;
+            const body = release.body || "";
+            const tag = release.tag_name;
+            const releaseUrl = release.html_url;
+
+            // GitHub generated notes include PR references like #123.
+            const prRefRegex = /#(\d+)/g;
+            const prNumbers = new Set();
+            let prMatch;
+            while ((prMatch = prRefRegex.exec(body)) !== null) {
+              prNumbers.add(Number(prMatch[1]));
+            }
+
+            const closeRegex = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
+            const issueNumbers = new Set();
+
+            for (const prNumber of prNumbers) {
+              try {
+                const prResp = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: prNumber,
+                });
+                const prBody = prResp.data.body || "";
+                let match;
+                while ((match = closeRegex.exec(prBody)) !== null) {
+                  issueNumbers.add(Number(match[1]));
+                }
+              } catch (error) {
+                // Ignore non-PR references.
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
+            if (issueNumbers.size === 0) {
+              core.info("No linked issues found in release PR references.");
+              return;
+            }
+
+            // Ensure labels exist.
+            const ensureLabel = async (name, color, description) => {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status === 404) {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name,
+                    color,
+                    description,
+                  });
+                } else {
+                  throw error;
+                }
+              }
+            };
+
+            await ensureLabel("released", "0E8A16", "Issue is included in a published release");
+            await ensureLabel("in-progress", "1D76DB", "Issue is linked to an open pull request");
+            await ensureLabel("awaiting-release", "FBCA04", "Issue fixed on main and waiting for a tagged release");
+
+            for (const issueNumber of issueNumbers) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: `Fixed and released in \`${tag}\`: ${releaseUrl}`,
+              });
+
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                labels: ["released"],
+              });
+
+              // Best-effort cleanup; ignore if label isn't currently present.
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  name: "in-progress",
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  name: "awaiting-release",
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }

--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -614,7 +614,12 @@ func normalizeEnvironmentConnectionTypeForState(connectionType string) string {
 }
 
 func isAgentConnectionType(connectionType string) bool {
-	return strings.EqualFold(strings.TrimSpace(connectionType), "agent")
+	switch strings.ToLower(strings.TrimSpace(connectionType)) {
+	case "agent", "agent-standard", "agent-edge", "hawser-standard", "hawser-edge":
+		return true
+	default:
+		return false
+	}
 }
 
 func shouldProvisionAgentToken(plan environmentModel, prior environmentModel) bool {

--- a/internal/provider/resource_environment_test.go
+++ b/internal/provider/resource_environment_test.go
@@ -25,6 +25,25 @@ func TestBuildEnvironmentPayloadIncludesAgentTokenForAgentConnection(t *testing.
 	}
 }
 
+func TestBuildEnvironmentPayloadIncludesAgentTokenForAgentStandardConnection(t *testing.T) {
+	plan := environmentModel{
+		Name:           types.StringValue("agent-standard-env"),
+		ConnectionType: types.StringValue("agent-standard"),
+		AgentToken:     types.StringValue("agent-token-std"),
+	}
+
+	payload, err := buildEnvironmentPayload(plan, environmentModel{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if payload.HawserToken == nil || *payload.HawserToken != "agent-token-std" {
+		t.Fatalf("expected hawserToken in payload for agent-standard connection")
+	}
+	if payload.ConnectionType != "agent-standard" {
+		t.Fatalf("expected agent-standard connection type to be preserved, got %q", payload.ConnectionType)
+	}
+}
+
 func TestBuildEnvironmentPayloadDoesNotIncludeAgentTokenForNonAgentConnection(t *testing.T) {
 	plan := environmentModel{
 		Name:           types.StringValue("direct-env"),
@@ -57,6 +76,25 @@ func TestModelFromEnvironmentResponsePreservesPriorAgentTokenWhenRedacted(t *tes
 	}
 	if out.AgentToken.IsNull() || out.AgentToken.ValueString() != "configured-token" {
 		t.Fatalf("expected prior agent_token to be preserved when API omits token")
+	}
+}
+
+func TestModelFromEnvironmentResponsePreservesPriorAgentTokenForAgentStandard(t *testing.T) {
+	prior := environmentModel{
+		AgentToken: types.StringValue("configured-token"),
+	}
+	resp := &environmentResponse{
+		ID:             14,
+		Name:           "agent-std-env",
+		ConnectionType: "agent-standard",
+	}
+
+	out := modelFromEnvironmentResponse(prior, resp)
+	if out.ConnectionType.IsNull() || out.ConnectionType.ValueString() != "agent-standard" {
+		t.Fatalf("expected agent-standard connection type to be preserved in state")
+	}
+	if out.AgentToken.IsNull() || out.AgentToken.ValueString() != "configured-token" {
+		t.Fatalf("expected prior agent_token to be preserved for agent-standard connection")
 	}
 }
 
@@ -104,5 +142,28 @@ func TestShouldProvisionAgentTokenCreateAndChangeOnly(t *testing.T) {
 	}
 	if !shouldProvisionAgentToken(changedPlan, prior) {
 		t.Fatalf("expected changed token to reprovision")
+	}
+}
+
+func TestShouldProvisionAgentTokenForAgentStandard(t *testing.T) {
+	createPlan := environmentModel{
+		ConnectionType: types.StringValue("agent-standard"),
+		AgentToken:     types.StringValue("token-a"),
+	}
+	if !shouldProvisionAgentToken(createPlan, environmentModel{}) {
+		t.Fatalf("expected create flow to provision agent token for agent-standard")
+	}
+
+	prior := environmentModel{
+		ID:             types.StringValue("7"),
+		ConnectionType: types.StringValue("agent-standard"),
+		AgentToken:     types.StringValue("token-a"),
+	}
+	samePlan := environmentModel{
+		ConnectionType: types.StringValue("agent-standard"),
+		AgentToken:     types.StringValue("token-a"),
+	}
+	if shouldProvisionAgentToken(samePlan, prior) {
+		t.Fatalf("expected unchanged token to skip reprovision for agent-standard")
 	}
 }


### PR DESCRIPTION
## Summary
- fix `dockhand_environment` agent connection detection so `agent-standard`/`hawser-*` are treated as agent types
- prevent `agent_token` from being nulled after apply for agent-standard environments
- add regression tests for payload mapping, state preservation, and provisioning checks
- add issue lifecycle automation (PR issue-link guard + release issue notifier + PR template)

## Linked Issue
Fixes #2

## Validation
- [x] `go test ./...`

## Release Notes
- [x] User-facing behavior changed
