### PR TITLE
chore(dependabot): batch updates monthly by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,21 +3,29 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
+      day: "first-monday"
       time: "05:00"
       timezone: "America/New_York"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 2
+    groups:
+      gomod-monthly:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
+      day: "first-monday"
       time: "05:15"
       timezone: "America/New_York"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 2
+    groups:
+      actions-monthly:
+        patterns:
+          - "*"
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary
- switch Dependabot cadence from weekly to monthly for gomod and github-actions
- group updates by ecosystem so each cycle produces one PR per ecosystem
- reduce open PR limit to 2 per ecosystem to avoid queue churn

## Validation
- config updated in .github/dependabot.yml

Fixes #15