### PR TITLE
fix(acceptance): stabilize full harness and stack computed fields

### DIFF
--- a/internal/provider/resource_stack.go
+++ b/internal/provider/resource_stack.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -145,17 +146,11 @@ func (r *stackResource) Create(ctx context.Context, req resource.CreateRequest, 
 		}
 	}
 
-	stack, found, err := r.client.GetStackByName(ctx, env, name)
-	if err != nil {
+	plan.ID = types.StringValue(formatStackID(env, name))
+	if err := r.refreshStackObservedFields(ctx, env, name, &plan, nil); err != nil {
 		resp.Diagnostics.AddError("Error reading Dockhand stack after create", err.Error())
 		return
 	}
-	if found {
-		plan.Status = types.StringValue(stack.Status)
-		plan.ContainerIDs = stringSliceToListValue(stack.Containers)
-		plan.ContainerCount = types.Int64Value(int64(len(stack.Containers)))
-	}
-	plan.ID = types.StringValue(formatStackID(env, name))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -207,6 +202,10 @@ func (r *stackResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	if plan.Enabled.ValueBool() == state.Enabled.ValueBool() {
+		if err := r.refreshStackObservedFields(ctx, state.Env.ValueString(), state.Name.ValueString(), &plan, &state); err != nil {
+			resp.Diagnostics.AddError("Error refreshing Dockhand stack", err.Error())
+			return
+		}
 		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 		return
 	}
@@ -222,6 +221,11 @@ func (r *stackResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating Dockhand stack runtime state", err.Error())
+		return
+	}
+
+	if err := r.refreshStackObservedFields(ctx, env, name, &plan, &state); err != nil {
+		resp.Diagnostics.AddError("Error reading Dockhand stack after update", err.Error())
 		return
 	}
 
@@ -282,6 +286,74 @@ func formatStackID(env string, name string) string {
 		return name
 	}
 	return env + ":" + name
+}
+
+func (r *stackResource) refreshStackObservedFields(ctx context.Context, env string, name string, target *stackResourceModel, fallback *stackResourceModel) error {
+	stack, found, err := r.getStackByNameEventually(ctx, env, name)
+	if err != nil {
+		return err
+	}
+	if found {
+		target.Status = types.StringValue(stack.Status)
+		target.ContainerIDs = stringSliceToListValue(stack.Containers)
+		target.ContainerCount = types.Int64Value(int64(len(stack.Containers)))
+		return nil
+	}
+
+	if fallback != nil {
+		if !fallback.Status.IsUnknown() {
+			target.Status = fallback.Status
+		}
+		if !fallback.ContainerIDs.IsUnknown() {
+			target.ContainerIDs = fallback.ContainerIDs
+		}
+		if !fallback.ContainerCount.IsUnknown() {
+			target.ContainerCount = fallback.ContainerCount
+		}
+	}
+
+	if target.Status.IsUnknown() {
+		target.Status = types.StringNull()
+	}
+	if target.ContainerIDs.IsUnknown() || target.ContainerIDs.IsNull() {
+		target.ContainerIDs = stringSliceToListValue(nil)
+	}
+	if target.ContainerCount.IsUnknown() || target.ContainerCount.IsNull() {
+		target.ContainerCount = types.Int64Value(0)
+	}
+
+	return nil
+}
+
+func (r *stackResource) getStackByNameEventually(ctx context.Context, env string, name string) (*stackResponse, bool, error) {
+	var lastErr error
+	for attempt := 0; attempt < 6; attempt++ {
+		stack, found, err := r.client.GetStackByName(ctx, env, name)
+		if err == nil {
+			if found {
+				return stack, true, nil
+			}
+			if attempt == 5 {
+				return nil, false, nil
+			}
+		} else {
+			lastErr = err
+			if attempt == 5 {
+				return nil, false, err
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			if lastErr != nil {
+				return nil, false, lastErr
+			}
+			return nil, false, ctx.Err()
+		case <-time.After(350 * time.Millisecond):
+		}
+	}
+
+	return nil, false, lastErr
 }
 
 func stringSliceToListValue(values []string) types.List {

--- a/scripts/run-acceptance-harness.sh
+++ b/scripts/run-acceptance-harness.sh
@@ -13,7 +13,7 @@ DOCKHAND_TEST_ENDPOINT="${DOCKHAND_TEST_ENDPOINT:-http://127.0.0.1:13001}"
 DOCKHAND_TEST_USERNAME="${DOCKHAND_TEST_USERNAME:-tfacc}"
 DOCKHAND_TEST_PASSWORD="${DOCKHAND_TEST_PASSWORD:-tfaccpass123!}"
 DOCKHAND_TEST_AUTH_PROVIDER="${DOCKHAND_TEST_AUTH_PROVIDER:-local}"
-DOCKHAND_TEST_DIND_HOST="${DOCKHAND_TEST_DIND_HOST:-dind}"
+DOCKHAND_TEST_DIND_HOST="${DOCKHAND_TEST_DIND_HOST:-}"
 DOCKHAND_TEST_DIND_PORT="${DOCKHAND_TEST_DIND_PORT:-2375}"
 
 SUFFIX="$(date +%s)"
@@ -21,6 +21,10 @@ NETWORK_NAME="dockhand-ci-${SUFFIX}"
 DIND_CONTAINER="dind-${SUFFIX}"
 DOCKHAND_CONTAINER="dockhand-${SUFFIX}"
 HAWSER_CONTAINER="hawser-${SUFFIX}"
+
+if [[ -z "${DOCKHAND_TEST_DIND_HOST}" ]]; then
+  DOCKHAND_TEST_DIND_HOST="${DIND_CONTAINER}"
+fi
 
 cleanup() {
   docker --host "tcp://127.0.0.1:23750" rm -f "${HAWSER_CONTAINER}" >/dev/null 2>&1 || true
@@ -44,6 +48,8 @@ docker network create "${NETWORK_NAME}" >/dev/null
 
 echo "Starting DinD ${DIND_CONTAINER}"
 docker run -d --name "${DIND_CONTAINER}" --network "${NETWORK_NAME}" --privileged \
+  --network-alias "${DIND_CONTAINER}" \
+  --network-alias dind \
   -e DOCKER_TLS_CERTDIR= \
   -p 23750:2375 \
   "${DIND_IMAGE}" \
@@ -166,4 +172,3 @@ if [[ "${RUN_ENDPOINT_PROBE}" == "true" ]]; then
 fi
 
 echo "Acceptance harness completed successfully"
-


### PR DESCRIPTION
## Summary
- fix full acceptance harness DinD host resolution by defaulting host to the actual DinD container name and adding explicit network aliases
- make dockhand_stack create/update always persist known computed values (status, container_ids, container_count) after apply
- add short retry window for stack read-after-write to reduce eventual-consistency flakes

## Why
Acceptance Full run 22793358647 failed with:
- DockerConnectionError in pull-dependent tests
- invalid post-apply unknown values for dockhand_stack computed fields

## Validation
- local: GOCACHE=/Users/kharrison/Documents/github/kalebharrison/terraform-provider-dockhand/.cache/go-build GOMODCACHE=/Users/kharrison/Documents/github/kalebharrison/terraform-provider-dockhand/.cache/gomod go test ./...
- manually re-run Acceptance CI and Acceptance Full after this PR

Fixes #16