### PR TITLE
fix(git-stack): tear down runtime stack on destroy

### DIFF
--- a/internal/provider/resource_git_stack.go
+++ b/internal/provider/resource_git_stack.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -29,6 +30,12 @@ func NewGitStackResource() resource.Resource {
 
 type gitStackResource struct {
 	client *Client
+}
+
+type gitStackDestroyClient interface {
+	DeleteStack(ctx context.Context, env string, name string) (int, error)
+	GetStackByName(ctx context.Context, env string, name string) (*stackResponse, bool, error)
+	DeleteGitStack(ctx context.Context, env string, id string) (int, error)
 }
 
 type gitStackModel struct {
@@ -306,11 +313,34 @@ func (r *gitStackResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	status, err := r.client.DeleteGitStack(ctx, state.Env.ValueString(), state.ID.ValueString())
-	if err != nil && status != 404 {
+	env := strings.TrimSpace(r.client.resolveEnv(state.Env.ValueString()))
+	if err := destroyGitStack(ctx, r.client, env, state.ID.ValueString(), state.StackName.ValueString()); err != nil {
 		resp.Diagnostics.AddError("Error deleting Dockhand git stack", err.Error())
-		return
 	}
+}
+
+func destroyGitStack(ctx context.Context, client gitStackDestroyClient, env string, id string, stackName string) error {
+	stackName = strings.TrimSpace(stackName)
+	if stackName != "" {
+		// Remove runtime state first so a failed teardown does not orphan a running stack.
+		status, err := client.DeleteStack(ctx, env, stackName)
+		if err != nil && status != http.StatusNotFound {
+			_, found, readErr := client.GetStackByName(ctx, env, stackName)
+			if readErr != nil {
+				return fmt.Errorf("delete runtime stack %q: %w (confirm read failed: %v)", stackName, err, readErr)
+			}
+			if found {
+				return fmt.Errorf("delete runtime stack %q: %w", stackName, err)
+			}
+		}
+	}
+
+	status, err := client.DeleteGitStack(ctx, env, id)
+	if err != nil && status != http.StatusNotFound {
+		return fmt.Errorf("delete git stack record %q: %w", id, err)
+	}
+
+	return nil
 }
 
 func (r *gitStackResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/resource_git_stack_test.go
+++ b/internal/provider/resource_git_stack_test.go
@@ -1,10 +1,41 @@
 package provider
 
 import (
+	"context"
+	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+type fakeGitStackDestroyClient struct {
+	calls                []string
+	deleteStackStatus    int
+	deleteStackErr       error
+	getStackFound        bool
+	getStackErr          error
+	deleteGitStackStatus int
+	deleteGitStackErr    error
+}
+
+func (f *fakeGitStackDestroyClient) DeleteStack(_ context.Context, env string, name string) (int, error) {
+	f.calls = append(f.calls, "DeleteStack:"+env+":"+name)
+	return f.deleteStackStatus, f.deleteStackErr
+}
+
+func (f *fakeGitStackDestroyClient) GetStackByName(_ context.Context, env string, name string) (*stackResponse, bool, error) {
+	f.calls = append(f.calls, "GetStackByName:"+env+":"+name)
+	if f.getStackFound {
+		return &stackResponse{Name: name}, true, f.getStackErr
+	}
+	return nil, false, f.getStackErr
+}
+
+func (f *fakeGitStackDestroyClient) DeleteGitStack(_ context.Context, env string, id string) (int, error) {
+	f.calls = append(f.calls, "DeleteGitStack:"+env+":"+id)
+	return f.deleteGitStackStatus, f.deleteGitStackErr
+}
 
 func TestBuildGitStackPayloadWebhookDisabledAutoGenerateSendsEmptySecret(t *testing.T) {
 	plan := gitStackModel{
@@ -177,5 +208,91 @@ func TestModelFromGitStackResponseFallsBackToAutoUpdate(t *testing.T) {
 	}
 	if !model.AutoUpdateEnabled.ValueBool() {
 		t.Fatalf("expected AutoUpdateEnabled=true when falling back to autoUpdate")
+	}
+}
+
+func TestDestroyGitStackDeletesRuntimeBeforeGitRecord(t *testing.T) {
+	client := &fakeGitStackDestroyClient{
+		deleteStackStatus:    200,
+		deleteGitStackStatus: 200,
+	}
+
+	err := destroyGitStack(context.Background(), client, "11", "77", "ollama")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantCalls := []string{
+		"DeleteStack:11:ollama",
+		"DeleteGitStack:11:77",
+	}
+	if !reflect.DeepEqual(client.calls, wantCalls) {
+		t.Fatalf("unexpected call order: got=%v want=%v", client.calls, wantCalls)
+	}
+}
+
+func TestDestroyGitStackSkipsGitDeleteWhenRuntimeStillExists(t *testing.T) {
+	client := &fakeGitStackDestroyClient{
+		deleteStackStatus: 500,
+		deleteStackErr:    errors.New("runtime delete failed"),
+		getStackFound:     true,
+	}
+
+	err := destroyGitStack(context.Background(), client, "11", "77", "ollama")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	wantCalls := []string{
+		"DeleteStack:11:ollama",
+		"GetStackByName:11:ollama",
+	}
+	if !reflect.DeepEqual(client.calls, wantCalls) {
+		t.Fatalf("unexpected call order: got=%v want=%v", client.calls, wantCalls)
+	}
+}
+
+func TestDestroyGitStackContinuesWhenRuntimeAlreadyGone(t *testing.T) {
+	client := &fakeGitStackDestroyClient{
+		deleteStackStatus:    500,
+		deleteStackErr:       errors.New("runtime delete failed"),
+		getStackFound:        false,
+		deleteGitStackStatus: 200,
+	}
+
+	err := destroyGitStack(context.Background(), client, "11", "77", "ollama")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantCalls := []string{
+		"DeleteStack:11:ollama",
+		"GetStackByName:11:ollama",
+		"DeleteGitStack:11:77",
+	}
+	if !reflect.DeepEqual(client.calls, wantCalls) {
+		t.Fatalf("unexpected call order: got=%v want=%v", client.calls, wantCalls)
+	}
+}
+
+func TestDestroyGitStackTreatsNotFoundAsSuccess(t *testing.T) {
+	client := &fakeGitStackDestroyClient{
+		deleteStackStatus:    404,
+		deleteStackErr:       errors.New("not found"),
+		deleteGitStackStatus: 404,
+		deleteGitStackErr:    errors.New("not found"),
+	}
+
+	err := destroyGitStack(context.Background(), client, "11", "77", "ollama")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantCalls := []string{
+		"DeleteStack:11:ollama",
+		"DeleteGitStack:11:77",
+	}
+	if !reflect.DeepEqual(client.calls, wantCalls) {
+		t.Fatalf("unexpected call order: got=%v want=%v", client.calls, wantCalls)
 	}
 }

--- a/internal/provider/resource_git_stack_tf_acc_test.go
+++ b/internal/provider/resource_git_stack_tf_acc_test.go
@@ -1,0 +1,147 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccGitStackResourceDestroyRemovesRuntimeTerraform(t *testing.T) {
+	endpoint, username, password := testAccEnv(t)
+	defaultEnv := testAccDefaultEnv()
+	repoURL := strings.TrimSpace(os.Getenv("DOCKHAND_TEST_GIT_STACK_REPO_URL"))
+	composePath := strings.TrimSpace(os.Getenv("DOCKHAND_TEST_GIT_STACK_COMPOSE_PATH"))
+	if repoURL == "" || composePath == "" {
+		t.Skip("acceptance test requires DOCKHAND_TEST_GIT_STACK_REPO_URL and DOCKHAND_TEST_GIT_STACK_COMPOSE_PATH")
+	}
+
+	branch := strings.TrimSpace(os.Getenv("DOCKHAND_TEST_GIT_STACK_BRANCH"))
+	if branch == "" {
+		branch = "main"
+	}
+	credentialID := strings.TrimSpace(os.Getenv("DOCKHAND_TEST_GIT_STACK_CREDENTIAL_ID"))
+
+	t.Setenv("DOCKHAND_ENDPOINT", endpoint)
+	t.Setenv("DOCKHAND_USERNAME", username)
+	t.Setenv("DOCKHAND_PASSWORD", password)
+	t.Setenv("DOCKHAND_DEFAULT_ENV", defaultEnv)
+
+	stackName := "tf-acc-git-stack-" + strings.ToLower(time.Now().UTC().Format("20060102150405"))
+	resourceName := "dockhand_git_stack.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProviderFactories(),
+		CheckDestroy:             testAccCheckGitStackDestroyed(endpoint, username, password),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGitStackConfig(defaultEnv, stackName, repoURL, branch, composePath, credentialID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "env", defaultEnv),
+					resource.TestCheckResourceAttr(resourceName, "stack_name", stackName),
+					resource.TestCheckResourceAttr(resourceName, "compose_path", composePath),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					testAccCheckRuntimeStackExists(endpoint, username, password, defaultEnv, stackName),
+				),
+			},
+		},
+	})
+}
+
+func testAccGitStackConfig(env string, stackName string, repoURL string, branch string, composePath string, credentialID string) string {
+	credentialBlock := ""
+	if strings.TrimSpace(credentialID) != "" {
+		credentialBlock = fmt.Sprintf("\n  credential_id = %q", credentialID)
+	}
+
+	return fmt.Sprintf(`
+provider "dockhand" {}
+
+resource "dockhand_git_stack" "test" {
+  env          = %q
+  stack_name   = %q
+  url          = %q
+  branch       = %q
+  compose_path = %q
+  deploy_now   = true%s
+}
+`, env, stackName, repoURL, branch, composePath, credentialBlock)
+}
+
+func testAccCheckRuntimeStackExists(endpoint string, username string, password string, env string, stackName string) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		sessionCookie, err := testAccLoginSessionCookieForDestroy(endpoint, username, password)
+		if err != nil {
+			return err
+		}
+
+		client, err := NewClient(endpoint, sessionCookie, env, true)
+		if err != nil {
+			return err
+		}
+
+		deadline := time.Now().Add(90 * time.Second)
+		for {
+			_, found, err := client.GetStackByName(context.Background(), env, stackName)
+			if err == nil && found {
+				return nil
+			}
+			if time.Now().After(deadline) {
+				if err != nil {
+					return fmt.Errorf("check runtime stack existence for %q: %w", stackName, err)
+				}
+				return fmt.Errorf("runtime stack %q was not observed after deploy", stackName)
+			}
+			time.Sleep(5 * time.Second)
+		}
+	}
+}
+
+func testAccCheckGitStackDestroyed(endpoint string, username string, password string) func(state *terraform.State) error {
+	return func(state *terraform.State) error {
+		sessionCookie, err := testAccLoginSessionCookieForDestroy(endpoint, username, password)
+		if err != nil {
+			return err
+		}
+
+		client, err := NewClient(endpoint, sessionCookie, "", true)
+		if err != nil {
+			return err
+		}
+
+		for _, rs := range state.RootModule().Resources {
+			if rs.Type != "dockhand_git_stack" {
+				continue
+			}
+
+			env := strings.TrimSpace(rs.Primary.Attributes["env"])
+			if env == "" {
+				env = testAccDefaultEnv()
+			}
+			stackName := strings.TrimSpace(rs.Primary.Attributes["stack_name"])
+
+			item, _, err := client.GetGitStackByID(context.Background(), env, rs.Primary.ID)
+			if err != nil {
+				return fmt.Errorf("check git stack destroy: %w", err)
+			}
+			if item != nil {
+				return fmt.Errorf("git stack still exists: id=%s", rs.Primary.ID)
+			}
+
+			_, found, err := client.GetStackByName(context.Background(), env, stackName)
+			if err != nil {
+				return fmt.Errorf("check runtime stack destroy: %w", err)
+			}
+			if found {
+				return fmt.Errorf("runtime stack still exists: env=%s name=%s", env, stackName)
+			}
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
Fixes #44

## Summary
- delete the runtime stack as part of `dockhand_git_stack` destroy
- keep the git stack record in place if runtime teardown fails, so Terraform can retry cleanly
- add destroy-sequencing unit coverage and an opt-in acceptance test for end-to-end cleanup

## Testing
- GOCACHE=$PWD/.cache/go-build GOMODCACHE=$PWD/.cache/gomod go test ./...
- /bin/zsh -lc "export GOCACHE=$PWD/.cache/go-build GOMODCACHE=$PWD/.cache/gomod; ./scripts/verify.sh --quality"