### PR TITLE
ci: publish releases explicitly after gh upload

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -153,3 +153,7 @@ jobs:
               --title "${tag}" \
               --generate-notes
           fi
+
+          # gh release create can leave the release in draft state depending on
+          # repository defaults, so publish it explicitly.
+          gh release edit "${tag}" --draft=false --latest


### PR DESCRIPTION
Fixes #52

## Summary
- publish releases explicitly after the `gh release create/upload` path
- keep the Node 20-free release workflow while restoring published release behavior

## Testing
- ./scripts/verify.sh --quality