### PR TITLE
fix: normalize container host_port payload to integer

### DIFF
--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -71,7 +71,7 @@ type stackResponse struct {
 
 type containerPortPayload struct {
 	ContainerPort int64  `json:"containerPort"`
-	HostPort      string `json:"hostPort"`
+	HostPort      int64  `json:"hostPort"`
 	Protocol      string `json:"protocol,omitempty"`
 }
 

--- a/internal/provider/resource_container.go
+++ b/internal/provider/resource_container.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -247,12 +248,18 @@ func (r *containerResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	portsPayload, flattenErr := flattenContainerPorts(plan.Ports)
+	if flattenErr != nil {
+		resp.Diagnostics.AddError("Invalid container port mapping", flattenErr.Error())
+		return
+	}
+
 	payload := containerPayload{
 		Name:   plan.Name.ValueString(),
 		Image:  plan.Image.ValueString(),
 		Env:    flattenEnvVars(ctx, plan.EnvVars),
 		Labels: flattenStringMap(ctx, plan.Labels),
-		Ports:  flattenContainerPorts(plan.Ports),
+		Ports:  portsPayload,
 	}
 	if v := stringPtrFromStringValue(plan.Command); v != nil {
 		payload.Command = v
@@ -549,24 +556,35 @@ func flattenStringMap(ctx context.Context, value types.Map) map[string]string {
 	return out
 }
 
-func flattenContainerPorts(values []containerPortModel) []containerPortPayload {
+func flattenContainerPorts(values []containerPortModel) ([]containerPortPayload, error) {
 	if len(values) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	out := make([]containerPortPayload, 0, len(values))
-	for _, p := range values {
+	for i, p := range values {
+		containerPort := p.ContainerPort.ValueInt64()
+		if containerPort <= 0 {
+			return nil, fmt.Errorf("ports[%d].container_port must be greater than zero", i)
+		}
+
+		hostPortRaw := strings.TrimSpace(p.HostPort.ValueString())
+		hostPort, err := strconv.ParseInt(hostPortRaw, 10, 64)
+		if err != nil || hostPort <= 0 {
+			return nil, fmt.Errorf("ports[%d].host_port must be a positive integer string", i)
+		}
+
 		protocol := strings.TrimSpace(p.Protocol.ValueString())
 		if protocol == "" {
 			protocol = "tcp"
 		}
 		out = append(out, containerPortPayload{
-			ContainerPort: p.ContainerPort.ValueInt64(),
-			HostPort:      p.HostPort.ValueString(),
+			ContainerPort: containerPort,
+			HostPort:      hostPort,
 			Protocol:      protocol,
 		})
 	}
-	return out
+	return out, nil
 }
 
 func stringPtrFromStringValue(value types.String) *string {

--- a/internal/provider/resource_container_test.go
+++ b/internal/provider/resource_container_test.go
@@ -1,6 +1,10 @@
 package provider
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
 
 func TestParseContainerUpdatePayload(t *testing.T) {
 	t.Run("valid object", func(t *testing.T) {
@@ -16,6 +20,40 @@ func TestParseContainerUpdatePayload(t *testing.T) {
 	t.Run("invalid json", func(t *testing.T) {
 		if _, err := parseContainerUpdatePayload(`{bad`); err == nil {
 			t.Fatalf("expected error for invalid json")
+		}
+	})
+}
+
+func TestFlattenContainerPorts(t *testing.T) {
+	t.Run("converts host_port string to numeric payload", func(t *testing.T) {
+		ports, err := flattenContainerPorts([]containerPortModel{
+			{
+				ContainerPort: types.Int64Value(80),
+				HostPort:      types.StringValue("80"),
+				Protocol:      types.StringNull(),
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ports) != 1 {
+			t.Fatalf("expected 1 port payload, got %d", len(ports))
+		}
+		if ports[0].ContainerPort != 80 || ports[0].HostPort != 80 || ports[0].Protocol != "tcp" {
+			t.Fatalf("unexpected payload: %+v", ports[0])
+		}
+	})
+
+	t.Run("rejects invalid host_port", func(t *testing.T) {
+		_, err := flattenContainerPorts([]containerPortModel{
+			{
+				ContainerPort: types.Int64Value(80),
+				HostPort:      types.StringValue("abc"),
+				Protocol:      types.StringValue("tcp"),
+			},
+		})
+		if err == nil {
+			t.Fatalf("expected error for invalid host_port")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- parse `dockhand_container.ports[*].host_port` as a positive integer string before API submission
- send numeric `hostPort` in the create payload to match Dockhand container create expectations
- add unit tests covering successful conversion and invalid host port validation

## Verification
- `./scripts/verify.sh --quality`
- `./scripts/verify.sh --acceptance --test-regex 'TestAcc(EnvironmentResourceTerraform|ContainerRenameActionTerraform)'` *(fails in this environment: `docker: command not found`)*

Closes #60
