### PR TITLE
fix(environment): preserve hawser-standard connection type

### DIFF
--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -606,7 +606,7 @@ func normalizeEnvironmentConnectionTypeForAPI(connectionType string) string {
 func normalizeEnvironmentConnectionTypeForState(connectionType string) string {
 	v := strings.ToLower(strings.TrimSpace(connectionType))
 	switch v {
-	case "hawser-edge", "hawser-standard":
+	case "hawser-edge":
 		return "agent"
 	default:
 		return strings.TrimSpace(connectionType)

--- a/internal/provider/resource_environment_test.go
+++ b/internal/provider/resource_environment_test.go
@@ -98,6 +98,26 @@ func TestModelFromEnvironmentResponsePreservesPriorAgentTokenForAgentStandard(t 
 	}
 }
 
+func TestModelFromEnvironmentResponsePreservesHawserStandardConnectionType(t *testing.T) {
+	prior := environmentModel{
+		ConnectionType: types.StringValue("hawser-standard"),
+		AgentToken:     types.StringValue("configured-token"),
+	}
+	resp := &environmentResponse{
+		ID:             15,
+		Name:           "hawser-standard-env",
+		ConnectionType: "hawser-standard",
+	}
+
+	out := modelFromEnvironmentResponse(prior, resp)
+	if out.ConnectionType.IsNull() || out.ConnectionType.ValueString() != "hawser-standard" {
+		t.Fatalf("expected hawser-standard connection type to be preserved in state")
+	}
+	if out.AgentToken.IsNull() || out.AgentToken.ValueString() != "configured-token" {
+		t.Fatalf("expected prior agent_token to be preserved for hawser-standard")
+	}
+}
+
 func TestModelFromEnvironmentResponseClearsAgentTokenForNonAgentConnection(t *testing.T) {
 	prior := environmentModel{
 		AgentToken: types.StringValue("configured-token"),


### PR DESCRIPTION
## Summary
- preserve `hawser-standard` in Terraform state instead of normalizing it to `agent`
- keep existing alias behavior for `agent`/`hawser-edge`
- add regression test covering `hawser-standard` round-trip behavior

## Verification
- `./scripts/verify.sh --quality`
- `./scripts/verify.sh --acceptance --test-regex 'TestAcc(EnvironmentResourceAgentTokenTerraform|EnvironmentResourceDirectDinDTerraform)'` *(fails locally: `docker: command not found`)*

Closes #62
