### PR TITLE
fix: add trigger support to dockhand_stack_env

### DIFF
--- a/docs/resources/stack_env.md
+++ b/docs/resources/stack_env.md
@@ -8,6 +8,7 @@ Manages stack `.env` raw content and secret variables.
 resource "dockhand_stack_env" "example" {
   env        = "2"
   stack_name = "my-stack"
+  trigger    = "stack-compose-sha256"
 
   raw_content = <<-EOT
 APP_ENV=prod
@@ -35,6 +36,7 @@ EOT
 - `env` (String)
 - `raw_content` (String)
 - `secret_variables` (List of Object)
+- `trigger` (String) Arbitrary value to force an update/re-sync when changed.
 
 ### Read-Only
 

--- a/examples/resources/dockhand_stack_env/resource.tf
+++ b/examples/resources/dockhand_stack_env/resource.tf
@@ -1,6 +1,7 @@
 resource "dockhand_stack_env" "example" {
   env        = "2"
   stack_name = "my-stack"
+  trigger    = "stack-compose-sha256"
 
   raw_content = <<-EOT
 APP_ENV=prod

--- a/internal/provider/resource_new_surfaces_tf_acc_test.go
+++ b/internal/provider/resource_new_surfaces_tf_acc_test.go
@@ -126,19 +126,21 @@ func TestAccStackEnvResourceTerraform(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProviderFactories(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStackEnvConfig(defaultEnv, stackName, "API_KEY=abc\n", "TOKEN", "secret-1"),
+				Config: testAccStackEnvConfig(defaultEnv, stackName, "API_KEY=abc\n", "TOKEN", "secret-1", "acc-run-1"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("dockhand_stack_env.test", "stack_name", stackName),
 					resource.TestCheckResourceAttr("dockhand_stack_env.test", "raw_content", "API_KEY=abc\n"),
 					resource.TestCheckResourceAttr("dockhand_stack_env.test", "secret_variables.0.key", "TOKEN"),
 					resource.TestCheckResourceAttr("dockhand_stack_env.test", "secret_variables.0.value", "secret-1"),
+					resource.TestCheckResourceAttr("dockhand_stack_env.test", "trigger", "acc-run-1"),
 				),
 			},
 			{
-				Config: testAccStackEnvConfig(defaultEnv, stackName, "API_KEY=xyz\n", "TOKEN", "secret-2"),
+				Config: testAccStackEnvConfig(defaultEnv, stackName, "API_KEY=xyz\n", "TOKEN", "secret-2", "acc-run-2"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("dockhand_stack_env.test", "raw_content", "API_KEY=xyz\n"),
 					resource.TestCheckResourceAttr("dockhand_stack_env.test", "secret_variables.0.value", "secret-2"),
+					resource.TestCheckResourceAttr("dockhand_stack_env.test", "trigger", "acc-run-2"),
 				),
 			},
 		},
@@ -751,7 +753,7 @@ resource "dockhand_stack_action" "down" {
 `, env, stackName, env, trigger)
 }
 
-func testAccStackEnvConfig(env string, stackName string, raw string, key string, value string) string {
+func testAccStackEnvConfig(env string, stackName string, raw string, key string, value string, trigger string) string {
 	return fmt.Sprintf(`
 provider "dockhand" {}
 
@@ -770,6 +772,7 @@ YAML
 resource "dockhand_stack_env" "test" {
   env        = %q
   stack_name = dockhand_stack.test.name
+  trigger    = %q
   raw_content = %q
   secret_variables = [
     {
@@ -779,7 +782,7 @@ resource "dockhand_stack_env" "test" {
     }
   ]
 }
-`, env, stackName, env, raw, key, value)
+`, env, stackName, env, trigger, raw, key, value)
 }
 
 func testAccGitStackEnvFileConfig(stackID string, path string, trigger string) string {

--- a/internal/provider/resource_stack_env.go
+++ b/internal/provider/resource_stack_env.go
@@ -39,6 +39,7 @@ type stackEnvResourceModel struct {
 	ID              types.String `tfsdk:"id"`
 	Env             types.String `tfsdk:"env"`
 	StackName       types.String `tfsdk:"stack_name"`
+	Trigger         types.String `tfsdk:"trigger"`
 	RawContent      types.String `tfsdk:"raw_content"`
 	SecretVariables types.List   `tfsdk:"secret_variables"`
 }
@@ -71,6 +72,10 @@ func (r *stackEnvResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+			},
+			"trigger": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Arbitrary value to force an update/re-sync when changed.",
 			},
 			"raw_content": schema.StringAttribute{
 				Optional: true,


### PR DESCRIPTION
## Summary
- add optional `trigger` attribute to `dockhand_stack_env` schema/state
- document and example the new trigger usage
- update acceptance coverage to assert trigger changes across applies

## Verification
- ./scripts/verify.sh --quality
- ./scripts/verify.sh --acceptance --test-regex 'TestAccStackEnvResourceTerraform' *(fails locally: docker not installed)*

Closes #66
