### PR TITLE
fix: install terraform in acceptance workflows

### DIFF
--- a/.github/workflows/acceptance-ci.yml
+++ b/.github/workflows/acceptance-ci.yml
@@ -68,7 +68,7 @@ jobs:
 
           curl -fsSL \
             "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_${arch}.zip" \
-            -o "${RUNNER_TEMP}/terraform.zip"
+            -o "${RUNNER_TEMP}/terraform_${version}_linux_${arch}.zip"
           curl -fsSL \
             "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_SHA256SUMS" \
             -o "${RUNNER_TEMP}/terraform_SHA256SUMS"
@@ -77,7 +77,7 @@ jobs:
             cd "${RUNNER_TEMP}"
             grep "terraform_${version}_linux_${arch}.zip" terraform_SHA256SUMS | sha256sum --check --status
           )
-          unzip -q "${RUNNER_TEMP}/terraform.zip" -d "${install_dir}"
+          unzip -q "${RUNNER_TEMP}/terraform_${version}_linux_${arch}.zip" -d "${install_dir}"
 
           terraform_path="${install_dir}/terraform"
           echo "TF_ACC_TERRAFORM_PATH=${terraform_path}" >> "${GITHUB_ENV}"

--- a/.github/workflows/acceptance-ci.yml
+++ b/.github/workflows/acceptance-ci.yml
@@ -73,7 +73,10 @@ jobs:
             "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_SHA256SUMS" \
             -o "${RUNNER_TEMP}/terraform_SHA256SUMS"
 
-          grep "terraform_${version}_linux_${arch}.zip" "${RUNNER_TEMP}/terraform_SHA256SUMS" | sha256sum --check --status
+          (
+            cd "${RUNNER_TEMP}"
+            grep "terraform_${version}_linux_${arch}.zip" terraform_SHA256SUMS | sha256sum --check --status
+          )
           unzip -q "${RUNNER_TEMP}/terraform.zip" -d "${install_dir}"
 
           terraform_path="${install_dir}/terraform"

--- a/.github/workflows/acceptance-ci.yml
+++ b/.github/workflows/acceptance-ci.yml
@@ -40,6 +40,46 @@ jobs:
           check-latest: true
           cache: true
 
+      - name: Ensure Terraform CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if command -v terraform >/dev/null 2>&1; then
+            terraform_path="$(command -v terraform)"
+            echo "TF_ACC_TERRAFORM_PATH=${terraform_path}" >> "${GITHUB_ENV}"
+            "${terraform_path}" version
+            exit 0
+          fi
+
+          version="1.14.8"
+          arch="$(uname -m)"
+          case "${arch}" in
+            x86_64) arch="amd64" ;;
+            arm64|aarch64) arch="arm64" ;;
+            *)
+              echo "unsupported architecture for Terraform download: ${arch}" >&2
+              exit 1
+              ;;
+          esac
+
+          install_dir="${RUNNER_TEMP}/terraform-${version}"
+          mkdir -p "${install_dir}"
+
+          curl -fsSL \
+            "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_${arch}.zip" \
+            -o "${RUNNER_TEMP}/terraform.zip"
+          curl -fsSL \
+            "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_SHA256SUMS" \
+            -o "${RUNNER_TEMP}/terraform_SHA256SUMS"
+
+          grep "terraform_${version}_linux_${arch}.zip" "${RUNNER_TEMP}/terraform_SHA256SUMS" | sha256sum --check --status
+          unzip -q "${RUNNER_TEMP}/terraform.zip" -d "${install_dir}"
+
+          terraform_path="${install_dir}/terraform"
+          echo "TF_ACC_TERRAFORM_PATH=${terraform_path}" >> "${GITHUB_ENV}"
+          "${terraform_path}" version
+
       - name: Validate acceptance manifest parity
         shell: bash
         run: |

--- a/.github/workflows/acceptance-full.yml
+++ b/.github/workflows/acceptance-full.yml
@@ -70,7 +70,7 @@ jobs:
 
           curl -fsSL \
             "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_${arch}.zip" \
-            -o "${RUNNER_TEMP}/terraform.zip"
+            -o "${RUNNER_TEMP}/terraform_${version}_linux_${arch}.zip"
           curl -fsSL \
             "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_SHA256SUMS" \
             -o "${RUNNER_TEMP}/terraform_SHA256SUMS"
@@ -79,7 +79,7 @@ jobs:
             cd "${RUNNER_TEMP}"
             grep "terraform_${version}_linux_${arch}.zip" terraform_SHA256SUMS | sha256sum --check --status
           )
-          unzip -q "${RUNNER_TEMP}/terraform.zip" -d "${install_dir}"
+          unzip -q "${RUNNER_TEMP}/terraform_${version}_linux_${arch}.zip" -d "${install_dir}"
 
           terraform_path="${install_dir}/terraform"
           echo "TF_ACC_TERRAFORM_PATH=${terraform_path}" >> "${GITHUB_ENV}"

--- a/.github/workflows/acceptance-full.yml
+++ b/.github/workflows/acceptance-full.yml
@@ -42,6 +42,46 @@ jobs:
           check-latest: true
           cache: true
 
+      - name: Ensure Terraform CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if command -v terraform >/dev/null 2>&1; then
+            terraform_path="$(command -v terraform)"
+            echo "TF_ACC_TERRAFORM_PATH=${terraform_path}" >> "${GITHUB_ENV}"
+            "${terraform_path}" version
+            exit 0
+          fi
+
+          version="1.14.8"
+          arch="$(uname -m)"
+          case "${arch}" in
+            x86_64) arch="amd64" ;;
+            arm64|aarch64) arch="arm64" ;;
+            *)
+              echo "unsupported architecture for Terraform download: ${arch}" >&2
+              exit 1
+              ;;
+          esac
+
+          install_dir="${RUNNER_TEMP}/terraform-${version}"
+          mkdir -p "${install_dir}"
+
+          curl -fsSL \
+            "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_${arch}.zip" \
+            -o "${RUNNER_TEMP}/terraform.zip"
+          curl -fsSL \
+            "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_SHA256SUMS" \
+            -o "${RUNNER_TEMP}/terraform_SHA256SUMS"
+
+          grep "terraform_${version}_linux_${arch}.zip" "${RUNNER_TEMP}/terraform_SHA256SUMS" | sha256sum --check --status
+          unzip -q "${RUNNER_TEMP}/terraform.zip" -d "${install_dir}"
+
+          terraform_path="${install_dir}/terraform"
+          echo "TF_ACC_TERRAFORM_PATH=${terraform_path}" >> "${GITHUB_ENV}"
+          "${terraform_path}" version
+
       - name: Validate acceptance manifest parity
         shell: bash
         run: |
@@ -55,4 +95,3 @@ jobs:
         run: |
           set -euo pipefail
           ./scripts/run-acceptance-harness.sh
-

--- a/.github/workflows/acceptance-full.yml
+++ b/.github/workflows/acceptance-full.yml
@@ -75,7 +75,10 @@ jobs:
             "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_SHA256SUMS" \
             -o "${RUNNER_TEMP}/terraform_SHA256SUMS"
 
-          grep "terraform_${version}_linux_${arch}.zip" "${RUNNER_TEMP}/terraform_SHA256SUMS" | sha256sum --check --status
+          (
+            cd "${RUNNER_TEMP}"
+            grep "terraform_${version}_linux_${arch}.zip" terraform_SHA256SUMS | sha256sum --check --status
+          )
           unzip -q "${RUNNER_TEMP}/terraform.zip" -d "${install_dir}"
 
           terraform_path="${install_dir}/terraform"

--- a/.github/workflows/dockhand-release-watch.yml
+++ b/.github/workflows/dockhand-release-watch.yml
@@ -185,7 +185,10 @@ jobs:
             "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_SHA256SUMS" \
             -o "${RUNNER_TEMP}/terraform_SHA256SUMS"
 
-          grep "terraform_${version}_linux_${arch}.zip" "${RUNNER_TEMP}/terraform_SHA256SUMS" | sha256sum --check --status
+          (
+            cd "${RUNNER_TEMP}"
+            grep "terraform_${version}_linux_${arch}.zip" terraform_SHA256SUMS | sha256sum --check --status
+          )
           unzip -q "${RUNNER_TEMP}/terraform.zip" -d "${install_dir}"
 
           terraform_path="${install_dir}/terraform"

--- a/.github/workflows/dockhand-release-watch.yml
+++ b/.github/workflows/dockhand-release-watch.yml
@@ -180,7 +180,7 @@ jobs:
 
           curl -fsSL \
             "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_${arch}.zip" \
-            -o "${RUNNER_TEMP}/terraform.zip"
+            -o "${RUNNER_TEMP}/terraform_${version}_linux_${arch}.zip"
           curl -fsSL \
             "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_SHA256SUMS" \
             -o "${RUNNER_TEMP}/terraform_SHA256SUMS"
@@ -189,7 +189,7 @@ jobs:
             cd "${RUNNER_TEMP}"
             grep "terraform_${version}_linux_${arch}.zip" terraform_SHA256SUMS | sha256sum --check --status
           )
-          unzip -q "${RUNNER_TEMP}/terraform.zip" -d "${install_dir}"
+          unzip -q "${RUNNER_TEMP}/terraform_${version}_linux_${arch}.zip" -d "${install_dir}"
 
           terraform_path="${install_dir}/terraform"
           echo "TF_ACC_TERRAFORM_PATH=${terraform_path}" >> "${GITHUB_ENV}"

--- a/.github/workflows/dockhand-release-watch.yml
+++ b/.github/workflows/dockhand-release-watch.yml
@@ -152,6 +152,46 @@ jobs:
           check-latest: true
           cache: true
 
+      - name: Ensure Terraform CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if command -v terraform >/dev/null 2>&1; then
+            terraform_path="$(command -v terraform)"
+            echo "TF_ACC_TERRAFORM_PATH=${terraform_path}" >> "${GITHUB_ENV}"
+            "${terraform_path}" version
+            exit 0
+          fi
+
+          version="1.14.8"
+          arch="$(uname -m)"
+          case "${arch}" in
+            x86_64) arch="amd64" ;;
+            arm64|aarch64) arch="arm64" ;;
+            *)
+              echo "unsupported architecture for Terraform download: ${arch}" >&2
+              exit 1
+              ;;
+          esac
+
+          install_dir="${RUNNER_TEMP}/terraform-${version}"
+          mkdir -p "${install_dir}"
+
+          curl -fsSL \
+            "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_${arch}.zip" \
+            -o "${RUNNER_TEMP}/terraform.zip"
+          curl -fsSL \
+            "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_SHA256SUMS" \
+            -o "${RUNNER_TEMP}/terraform_SHA256SUMS"
+
+          grep "terraform_${version}_linux_${arch}.zip" "${RUNNER_TEMP}/terraform_SHA256SUMS" | sha256sum --check --status
+          unzip -q "${RUNNER_TEMP}/terraform.zip" -d "${install_dir}"
+
+          terraform_path="${install_dir}/terraform"
+          echo "TF_ACC_TERRAFORM_PATH=${terraform_path}" >> "${GITHUB_ENV}"
+          "${terraform_path}" version
+
       - name: Validate acceptance manifest parity
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- install Terraform CLI in the acceptance and release-watch workflows before invoking the shared harness
- export `TF_ACC_TERRAFORM_PATH` so terraform-plugin-testing uses the preinstalled binary instead of self-installing
- keep the harness unchanged for local development

Fixes #84
Fixes #85
Fixes #93

## Validation
- `./scripts/verify.sh --quality`
- `ruby -e 'require "yaml"; [".github/workflows/acceptance-ci.yml", ".github/workflows/acceptance-full.yml", ".github/workflows/dockhand-release-watch.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'
