### PR TITLE
feat(provider): add git stack deploy options

### DIFF
--- a/docs/resources/git_stack.md
+++ b/docs/resources/git_stack.md
@@ -8,11 +8,14 @@ Use this resource when you want Dockhand to deploy/manage a stack from a Git rep
 
 ```terraform
 resource "dockhand_git_stack" "ollama" {
-  env           = "11"
-  stack_name    = "jetson01-ollama"
-  repository_id = "1"
-  compose_path  = "stacks/jetson01/enabled/ollama/stack.yaml"
-  deploy_now    = true
+  env            = "11"
+  stack_name     = "jetson01-ollama"
+  repository_id  = "1"
+  compose_path   = "stacks/jetson01/enabled/ollama/stack.yaml"
+  deploy_now     = true
+  build_on_deploy = true
+  repull_images   = false
+  force_redeploy  = false
 }
 ```
 
@@ -37,6 +40,9 @@ resource "dockhand_git_stack" "ollama" {
 - `webhook_enabled` (Boolean, default: `false`)
 - `webhook_secret` (String, Sensitive)
 - `deploy_now` (Boolean, default: `false`)
+- `build_on_deploy` (Boolean, default: `false`)
+- `repull_images` (Boolean, default: `false`)
+- `force_redeploy` (Boolean, default: `false`)
 - `env_vars_json` (String, default: `[]`)
 
 `repository_id` is preferred when you already manage the repository with `dockhand_git_repository`.

--- a/examples/resources/dockhand_git_stack/resource.tf
+++ b/examples/resources/dockhand_git_stack/resource.tf
@@ -1,7 +1,10 @@
 resource "dockhand_git_stack" "example" {
-  env           = "2"
-  stack_name    = "example-git-stack"
-  repository_id = "1"
-  compose_path  = "stacks/example/stack.yaml"
-  deploy_now    = true
+  env             = "2"
+  stack_name      = "example-git-stack"
+  repository_id   = "1"
+  compose_path    = "stacks/example/stack.yaml"
+  deploy_now      = true
+  build_on_deploy = true
+  repull_images   = false
+  force_redeploy  = false
 }

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -391,6 +391,9 @@ type gitStackPayload struct {
 	WebhookEnabled    bool                    `json:"webhookEnabled"`
 	WebhookSecret     *string                 `json:"webhookSecret,omitempty"`
 	DeployNow         bool                    `json:"deployNow"`
+	BuildOnDeploy     bool                    `json:"buildOnDeploy"`
+	RepullImages      bool                    `json:"repullImages"`
+	ForceRedeploy     bool                    `json:"forceRedeploy"`
 	EnvVars           []gitStackEnvVarPayload `json:"envVars,omitempty"`
 }
 
@@ -415,6 +418,9 @@ type gitStackResponse struct {
 	AutoUpdateCron     *string                     `json:"autoUpdateCron"`
 	WebhookEnabled     bool                        `json:"webhookEnabled"`
 	WebhookSecret      *string                     `json:"webhookSecret"`
+	BuildOnDeploy      *bool                       `json:"buildOnDeploy"`
+	RepullImages       *bool                       `json:"repullImages"`
+	ForceRedeploy      *bool                       `json:"forceRedeploy"`
 	LastSync           *string                     `json:"lastSync"`
 	LastCommit         *string                     `json:"lastCommit"`
 	SyncStatus         *string                     `json:"syncStatus"`

--- a/internal/provider/resource_git_stack.go
+++ b/internal/provider/resource_git_stack.go
@@ -55,6 +55,9 @@ type gitStackModel struct {
 	WebhookSecretAutoGenerate types.Bool   `tfsdk:"webhook_secret_auto_generate"`
 	WebhookSecret             types.String `tfsdk:"webhook_secret"`
 	DeployNow                 types.Bool   `tfsdk:"deploy_now"`
+	BuildOnDeploy             types.Bool   `tfsdk:"build_on_deploy"`
+	RepullImages              types.Bool   `tfsdk:"repull_images"`
+	ForceRedeploy             types.Bool   `tfsdk:"force_redeploy"`
 	EnvVarsJSON               types.String `tfsdk:"env_vars_json"`
 	LastSync                  types.String `tfsdk:"last_sync"`
 	LastCommit                types.String `tfsdk:"last_commit"`
@@ -158,6 +161,24 @@ func (r *gitStackResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 			"deploy_now": schema.BoolAttribute{
 				MarkdownDescription: "Whether to request immediate deployment when creating/updating this git stack.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+			},
+			"build_on_deploy": schema.BoolAttribute{
+				MarkdownDescription: "Whether Dockhand should build images on deploy.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+			},
+			"repull_images": schema.BoolAttribute{
+				MarkdownDescription: "Whether Dockhand should repull images on deploy.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+			},
+			"force_redeploy": schema.BoolAttribute{
+				MarkdownDescription: "Whether Dockhand should force a redeploy on deploy.",
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
@@ -384,6 +405,18 @@ func buildGitStackPayload(plan gitStackModel) (gitStackPayload, error) {
 	if !plan.DeployNow.IsNull() && !plan.DeployNow.IsUnknown() {
 		deployNow = plan.DeployNow.ValueBool()
 	}
+	buildOnDeploy := false
+	if !plan.BuildOnDeploy.IsNull() && !plan.BuildOnDeploy.IsUnknown() {
+		buildOnDeploy = plan.BuildOnDeploy.ValueBool()
+	}
+	repullImages := false
+	if !plan.RepullImages.IsNull() && !plan.RepullImages.IsUnknown() {
+		repullImages = plan.RepullImages.ValueBool()
+	}
+	forceRedeploy := false
+	if !plan.ForceRedeploy.IsNull() && !plan.ForceRedeploy.IsUnknown() {
+		forceRedeploy = plan.ForceRedeploy.ValueBool()
+	}
 
 	payload := gitStackPayload{
 		StackName:         stackName,
@@ -392,6 +425,9 @@ func buildGitStackPayload(plan gitStackModel) (gitStackPayload, error) {
 		AutoUpdateCron:    autoUpdateCron,
 		WebhookEnabled:    webhookEnabled,
 		DeployNow:         deployNow,
+		BuildOnDeploy:     buildOnDeploy,
+		RepullImages:      repullImages,
+		ForceRedeploy:     forceRedeploy,
 	}
 	// Support Dockhand API variants that use either autoUpdateEnabled or autoUpdate.
 	payload.AutoUpdate = &autoUpdateEnabled
@@ -532,6 +568,21 @@ func modelFromGitStackResponse(in *gitStackResponse) gitStackModel {
 	} else {
 		out.WebhookSecret = types.StringNull()
 	}
+	if in.BuildOnDeploy != nil {
+		out.BuildOnDeploy = types.BoolValue(*in.BuildOnDeploy)
+	} else {
+		out.BuildOnDeploy = types.BoolNull()
+	}
+	if in.RepullImages != nil {
+		out.RepullImages = types.BoolValue(*in.RepullImages)
+	} else {
+		out.RepullImages = types.BoolNull()
+	}
+	if in.ForceRedeploy != nil {
+		out.ForceRedeploy = types.BoolValue(*in.ForceRedeploy)
+	} else {
+		out.ForceRedeploy = types.BoolNull()
+	}
 	if in.LastSync != nil {
 		out.LastSync = types.StringValue(*in.LastSync)
 	} else {
@@ -619,6 +670,15 @@ func mergeGitStackState(preferred gitStackModel, remote gitStackModel) gitStackM
 	}
 	if !preferred.WebhookSecretAutoGenerate.IsNull() && !preferred.WebhookSecretAutoGenerate.IsUnknown() {
 		out.WebhookSecretAutoGenerate = preferred.WebhookSecretAutoGenerate
+	}
+	if (out.BuildOnDeploy.IsNull() || out.BuildOnDeploy.IsUnknown()) && !preferred.BuildOnDeploy.IsNull() && !preferred.BuildOnDeploy.IsUnknown() {
+		out.BuildOnDeploy = preferred.BuildOnDeploy
+	}
+	if (out.RepullImages.IsNull() || out.RepullImages.IsUnknown()) && !preferred.RepullImages.IsNull() && !preferred.RepullImages.IsUnknown() {
+		out.RepullImages = preferred.RepullImages
+	}
+	if (out.ForceRedeploy.IsNull() || out.ForceRedeploy.IsUnknown()) && !preferred.ForceRedeploy.IsNull() && !preferred.ForceRedeploy.IsUnknown() {
+		out.ForceRedeploy = preferred.ForceRedeploy
 	}
 	if (out.CredentialID.IsNull() || out.CredentialID.IsUnknown()) && !preferred.CredentialID.IsNull() && !preferred.CredentialID.IsUnknown() {
 		out.CredentialID = preferred.CredentialID

--- a/internal/provider/resource_git_stack_test.go
+++ b/internal/provider/resource_git_stack_test.go
@@ -136,6 +136,42 @@ func TestBuildGitStackPayloadSetsBothAutoUpdateKeys(t *testing.T) {
 	}
 }
 
+func TestBuildGitStackPayloadIncludesDeployOptions(t *testing.T) {
+	plan := gitStackModel{
+		StackName:                 types.StringValue("test-stack"),
+		ComposePath:               types.StringValue("docker-compose.yml"),
+		WebhookEnabled:            types.BoolValue(false),
+		WebhookSecretAutoGenerate: types.BoolValue(false),
+		WebhookSecret:             types.StringNull(),
+		AutoUpdateEnabled:         types.BoolValue(false),
+		AutoUpdateCron:            types.StringValue("0 3 * * *"),
+		DeployNow:                 types.BoolValue(true),
+		BuildOnDeploy:             types.BoolValue(true),
+		RepullImages:              types.BoolValue(false),
+		ForceRedeploy:             types.BoolValue(true),
+		EnvVarsJSON:               types.StringValue("[]"),
+		URL:                       types.StringValue("https://example.com/repo.git"),
+		Branch:                    types.StringValue("main"),
+	}
+
+	payload, err := buildGitStackPayload(plan)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !payload.DeployNow {
+		t.Fatalf("expected DeployNow true in payload")
+	}
+	if !payload.BuildOnDeploy {
+		t.Fatalf("expected BuildOnDeploy true in payload")
+	}
+	if payload.RepullImages {
+		t.Fatalf("expected RepullImages false in payload")
+	}
+	if !payload.ForceRedeploy {
+		t.Fatalf("expected ForceRedeploy true in payload")
+	}
+}
+
 func TestMergeGitStackStateWebhookSecretExplicitEmptyWins(t *testing.T) {
 	preferred := gitStackModel{WebhookSecret: types.StringValue("")}
 	remote := gitStackModel{WebhookSecret: types.StringValue("server-generated")}
@@ -208,6 +244,56 @@ func TestModelFromGitStackResponseFallsBackToAutoUpdate(t *testing.T) {
 	}
 	if !model.AutoUpdateEnabled.ValueBool() {
 		t.Fatalf("expected AutoUpdateEnabled=true when falling back to autoUpdate")
+	}
+}
+
+func TestModelFromGitStackResponseMapsDeployOptions(t *testing.T) {
+	buildOnDeploy := true
+	repullImages := false
+	forceRedeploy := true
+	resp := &gitStackResponse{
+		ID:             1,
+		StackName:      "test-stack",
+		AutoUpdate:     true,
+		WebhookEnabled: false,
+		BuildOnDeploy:  &buildOnDeploy,
+		RepullImages:   &repullImages,
+		ForceRedeploy:  &forceRedeploy,
+	}
+
+	model := modelFromGitStackResponse(resp)
+	if model.BuildOnDeploy.IsNull() || !model.BuildOnDeploy.ValueBool() {
+		t.Fatalf("expected BuildOnDeploy=true from response")
+	}
+	if model.RepullImages.IsNull() || model.RepullImages.ValueBool() {
+		t.Fatalf("expected RepullImages=false from response")
+	}
+	if model.ForceRedeploy.IsNull() || !model.ForceRedeploy.ValueBool() {
+		t.Fatalf("expected ForceRedeploy=true from response")
+	}
+}
+
+func TestMergeGitStackStatePreservesDeployOptionsWhenRemoteOmitsThem(t *testing.T) {
+	preferred := gitStackModel{
+		BuildOnDeploy: types.BoolValue(true),
+		RepullImages:  types.BoolValue(false),
+		ForceRedeploy: types.BoolValue(true),
+	}
+	remote := gitStackModel{
+		BuildOnDeploy: types.BoolNull(),
+		RepullImages:  types.BoolNull(),
+		ForceRedeploy: types.BoolNull(),
+	}
+
+	merged := mergeGitStackState(preferred, remote)
+	if merged.BuildOnDeploy.IsNull() || !merged.BuildOnDeploy.ValueBool() {
+		t.Fatalf("expected BuildOnDeploy to preserve configured true")
+	}
+	if merged.RepullImages.IsNull() || merged.RepullImages.ValueBool() {
+		t.Fatalf("expected RepullImages to preserve configured false")
+	}
+	if merged.ForceRedeploy.IsNull() || !merged.ForceRedeploy.ValueBool() {
+		t.Fatalf("expected ForceRedeploy to preserve configured true")
 	}
 }
 

--- a/internal/provider/resource_git_stack_tf_acc_test.go
+++ b/internal/provider/resource_git_stack_tf_acc_test.go
@@ -63,12 +63,15 @@ func testAccGitStackConfig(env string, stackName string, repoURL string, branch 
 provider "dockhand" {}
 
 resource "dockhand_git_stack" "test" {
-  env          = %q
-  stack_name   = %q
-  url          = %q
-  branch       = %q
-  compose_path = %q
-  deploy_now   = true%s
+  env             = %q
+  stack_name      = %q
+  url             = %q
+  branch          = %q
+  compose_path    = %q
+  deploy_now      = true
+  build_on_deploy = true
+  repull_images   = false
+  force_redeploy  = false%s
 }
 `, env, stackName, repoURL, branch, composePath, credentialBlock)
 }


### PR DESCRIPTION
## Summary
- add `build_on_deploy`, `repull_images`, and `force_redeploy` to `dockhand_git_stack`
- thread the new fields through the client payload and response mapping
- update docs, example usage, and tests

Fixes #94
