### PR TITLE
feat: add API token auth for provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ data "dockhand_health" "this" {}
 
 ## Authentication Modes
 
-The provider supports Dockhand's login-based authentication flow.
+The provider supports Dockhand's login-based authentication flow and bearer-token API auth.
 
 - Standard login: `endpoint`, `username`, `password`
+- API token auth: `endpoint`, `api_token`
 - Optional MFA: `mfa_token`
 - Optional provider selection: `auth_provider`
 - First-install bootstrap: `allow_unauthenticated = true`
@@ -167,6 +168,7 @@ Provider arguments:
 - `endpoint` — Dockhand API base URL
 - `username` — login username
 - `password` — login password
+- `api_token` — Dockhand API token for bearer-token auth
 - `mfa_token` — optional MFA token
 - `auth_provider` — optional auth provider ID, defaults to `local`
 - `default_env` — default environment ID for resources that omit `env`
@@ -178,6 +180,7 @@ Environment variable fallbacks:
 - `DOCKHAND_ENDPOINT`
 - `DOCKHAND_USERNAME`
 - `DOCKHAND_PASSWORD`
+- `DOCKHAND_API_TOKEN`
 - `DOCKHAND_MFA_TOKEN`
 - `DOCKHAND_AUTH_PROVIDER`
 - `DOCKHAND_DEFAULT_ENV`

--- a/docs/api-matrix.md
+++ b/docs/api-matrix.md
@@ -23,6 +23,7 @@ Live verification artifacts:
 | `provider.dockhand.endpoint` | Base URL | Supports `DOCKHAND_ENDPOINT`. | implemented |
 | `provider.dockhand.username` | Username | Supports `DOCKHAND_USERNAME`. | implemented |
 | `provider.dockhand.password` | Password | Supports `DOCKHAND_PASSWORD`. | implemented |
+| `provider.dockhand.api_token` | API token | Supports `DOCKHAND_API_TOKEN`; used as bearer-token auth. | implemented |
 | `provider.dockhand.mfa_token` | MFA token | Supports `DOCKHAND_MFA_TOKEN`. | implemented |
 | `provider.dockhand.auth_provider` | Auth provider | Supports `DOCKHAND_AUTH_PROVIDER`; defaults to `local`. | implemented |
 | `provider.dockhand.default_env` | `env` query default | Supports `DOCKHAND_DEFAULT_ENV`. | implemented |

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,15 @@ provider "dockhand" {
 }
 ```
 
+If you are using a Dockhand 1.0.25+ API token, use `api_token` instead of username/password:
+
+```terraform
+provider "dockhand" {
+  endpoint  = var.dockhand_endpoint
+  api_token = var.dockhand_api_token
+}
+```
+
 For a fresh, unauthenticated Dockhand install, bootstrap the first admin with:
 
 ```terraform
@@ -165,6 +174,7 @@ resource "dockhand_user" "admin" {
 - `endpoint` (String) Dockhand API base URL. Can also be set with `DOCKHAND_ENDPOINT`.
 - `username` (String) Username for login-based auth. Can also be set with `DOCKHAND_USERNAME`.
 - `password` (String, Sensitive) Password for login-based auth. Can also be set with `DOCKHAND_PASSWORD`.
+- `api_token` (String, Sensitive) Dockhand API token for bearer-token auth. Can also be set with `DOCKHAND_API_TOKEN`.
 - `mfa_token` (String, Sensitive) Optional MFA token for login-based auth. Can also be set with `DOCKHAND_MFA_TOKEN`.
 - `auth_provider` (String) Auth provider ID (default `local`). Can also be set with `DOCKHAND_AUTH_PROVIDER`.
 - `default_env` (String) Default environment ID used when resources omit `env`. Can also be set with `DOCKHAND_DEFAULT_ENV`.

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -21,6 +21,7 @@ type Client struct {
 	baseURL       *url.URL
 	httpClient    *http.Client
 	sessionCookie string
+	authHeader    string
 	defaultEnv    string
 }
 
@@ -915,7 +916,7 @@ type generalSettings struct {
 	TimeFormat                string   `json:"timeFormat"`
 }
 
-func NewClient(endpoint string, sessionCookie string, defaultEnv string, insecure bool) (*Client, error) {
+func NewClient(endpoint string, sessionCookie string, authHeader string, defaultEnv string, insecure bool) (*Client, error) {
 	if endpoint == "" {
 		return nil, fmt.Errorf("endpoint is required")
 	}
@@ -954,6 +955,7 @@ func NewClient(endpoint string, sessionCookie string, defaultEnv string, insecur
 			Transport: transport,
 		},
 		sessionCookie: sessionCookie,
+		authHeader:    authHeader,
 		defaultEnv:    defaultEnv,
 	}, nil
 }
@@ -1818,9 +1820,7 @@ func (c *Client) PullImage(ctx context.Context, env string, image string, scanAf
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
-	if c.sessionCookie != "" {
-		req.Header.Set("Cookie", c.sessionCookie)
-	}
+	c.applyAuthHeaders(req)
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
@@ -2071,9 +2071,7 @@ func (c *Client) ReadScheduleStream(ctx context.Context, maxEvents int64, timeou
 		return nil, 0, err
 	}
 	req.Header.Set("Accept", "text/event-stream")
-	if c.sessionCookie != "" {
-		req.Header.Set("Cookie", c.sessionCookie)
-	}
+	c.applyAuthHeaders(req)
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
@@ -2736,9 +2734,7 @@ func (c *Client) DeployGitStack(ctx context.Context, id string) (int, string, er
 	if err != nil {
 		return 0, "", err
 	}
-	if c.sessionCookie != "" {
-		req.Header.Set("Cookie", c.sessionCookie)
-	}
+	c.applyAuthHeaders(req)
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
@@ -2848,9 +2844,7 @@ func (c *Client) doJSONWithStatusUsingClient(ctx context.Context, httpClient *ht
 		if payloadBytes != nil {
 			req.Header.Set("Content-Type", "application/json")
 		}
-		if c.sessionCookie != "" {
-			req.Header.Set("Cookie", c.sessionCookie)
-		}
+		c.applyAuthHeaders(req)
 
 		//nolint:gosec // Provider endpoint is an explicit user-configured Dockhand API target.
 		res, err := httpClient.Do(req)
@@ -2915,6 +2909,15 @@ func (c *Client) resolveEnv(value string) string {
 		return value
 	}
 	return c.defaultEnv
+}
+
+func (c *Client) applyAuthHeaders(req *http.Request) {
+	if c.sessionCookie != "" {
+		req.Header.Set("Cookie", c.sessionCookie)
+	}
+	if c.authHeader != "" {
+		req.Header.Set("Authorization", c.authHeader)
+	}
 }
 
 func parseStacks(raw json.RawMessage) ([]stackResponse, error) {

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -1,16 +1,52 @@
 package provider
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
 func TestNewClientAllowsEmptySessionCookie(t *testing.T) {
 	t.Parallel()
 
-	client, err := NewClient("http://example.com", "", "1", true)
+	client, err := NewClient("http://example.com", "", "", "1", true)
 	if err != nil {
 		t.Fatalf("expected no error creating client without session cookie, got: %v", err)
 	}
 	if client == nil {
 		t.Fatalf("expected client instance, got nil")
+	}
+}
+
+func TestClientUsesBearerTokenAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	var gotCookie string
+	var gotAuth string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCookie = r.Header.Get("Cookie")
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL, "", "Bearer test-token", "1", false)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	var out map[string]any
+	if _, err := client.doJSONWithStatus(t.Context(), http.MethodGet, "/api/settings/general", nil, nil, &out); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	if gotCookie != "" {
+		t.Fatalf("expected no cookie auth header, got %q", gotCookie)
+	}
+	if gotAuth != "Bearer test-token" {
+		t.Fatalf("expected bearer auth header, got %q", gotAuth)
 	}
 }
 

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -1,8 +1,9 @@
 package provider
 
 import (
+	"io"
 	"net/http"
-	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -24,18 +25,21 @@ func TestClientUsesBearerTokenAuthHeader(t *testing.T) {
 	var gotCookie string
 	var gotAuth string
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotCookie = r.Header.Get("Cookie")
-		gotAuth = r.Header.Get("Authorization")
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"ok":true}`))
-	}))
-	defer server.Close()
-
-	client, err := NewClient(server.URL, "", "Bearer test-token", "1", false)
+	client, err := NewClient("http://example.com", "", "Bearer test-token", "1", false)
 	if err != nil {
 		t.Fatalf("NewClient() error = %v", err)
 	}
+
+	client.httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		gotCookie = r.Header.Get("Cookie")
+		gotAuth = r.Header.Get("Authorization")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			Header:     make(http.Header),
+			Request:    r,
+		}, nil
+	})
 
 	var out map[string]any
 	if _, err := client.doJSONWithStatus(t.Context(), http.MethodGet, "/api/settings/general", nil, nil, &out); err != nil {
@@ -48,6 +52,12 @@ func TestClientUsesBearerTokenAuthHeader(t *testing.T) {
 	if gotAuth != "Bearer test-token" {
 		t.Fatalf("expected bearer auth header, got %q", gotAuth)
 	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
 }
 
 func TestImagePullStreamError(t *testing.T) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -160,9 +160,10 @@ func (p *dockhandProvider) Configure(ctx context.Context, req provider.Configure
 
 	sessionCookie := ""
 	authHeader := ""
-	if apiToken != "" {
+	switch {
+	case apiToken != "":
 		authHeader = "Bearer " + apiToken
-	} else if username == "" && password == "" {
+	case username == "" && password == "":
 		if !allowUnauthenticated {
 			resp.Diagnostics.AddError(
 				"Missing Dockhand authentication",
@@ -174,7 +175,7 @@ func (p *dockhandProvider) Configure(ctx context.Context, req provider.Configure
 			"Unauthenticated provider mode enabled",
 			"The provider was initialized without login credentials. Only endpoints that Dockhand exposes without auth will work (for example initial bootstrap flows).",
 		)
-	} else {
+	default:
 		if username != "" && password == "" {
 			resp.Diagnostics.AddError(
 				"Incomplete Dockhand authentication",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -30,6 +30,7 @@ type dockhandProviderModel struct {
 	Endpoint             types.String `tfsdk:"endpoint"`
 	Username             types.String `tfsdk:"username"`
 	Password             types.String `tfsdk:"password"`
+	APIToken             types.String `tfsdk:"api_token"`
 	MFAToken             types.String `tfsdk:"mfa_token"`
 	AuthProvider         types.String `tfsdk:"auth_provider"`
 	DefaultEnv           types.String `tfsdk:"default_env"`
@@ -55,6 +56,11 @@ func (p *dockhandProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 			},
 			"password": schema.StringAttribute{
 				MarkdownDescription: "Dockhand password for login-based auth. Can also be set with `DOCKHAND_PASSWORD`.",
+				Optional:            true,
+				Sensitive:           true,
+			},
+			"api_token": schema.StringAttribute{
+				MarkdownDescription: "Dockhand API token for bearer-token auth. Can also be set with `DOCKHAND_API_TOKEN`.",
 				Optional:            true,
 				Sensitive:           true,
 			},
@@ -105,6 +111,11 @@ func (p *dockhandProvider) Configure(ctx context.Context, req provider.Configure
 		password = config.Password.ValueString()
 	}
 
+	apiToken := os.Getenv("DOCKHAND_API_TOKEN")
+	if !config.APIToken.IsNull() && !config.APIToken.IsUnknown() {
+		apiToken = config.APIToken.ValueString()
+	}
+
 	mfaToken := os.Getenv("DOCKHAND_MFA_TOKEN")
 	if !config.MFAToken.IsNull() && !config.MFAToken.IsUnknown() {
 		mfaToken = config.MFAToken.ValueString()
@@ -148,11 +159,14 @@ func (p *dockhandProvider) Configure(ctx context.Context, req provider.Configure
 	}
 
 	sessionCookie := ""
-	if username == "" && password == "" {
+	authHeader := ""
+	if apiToken != "" {
+		authHeader = "Bearer " + apiToken
+	} else if username == "" && password == "" {
 		if !allowUnauthenticated {
 			resp.Diagnostics.AddError(
 				"Missing Dockhand authentication",
-				"Set provider `username` and `password` (or export `DOCKHAND_USERNAME`/`DOCKHAND_PASSWORD`). For first-install bootstrap flows, set `allow_unauthenticated = true` (or `DOCKHAND_ALLOW_UNAUTHENTICATED=true`).",
+				"Set provider `username` and `password` (or export `DOCKHAND_USERNAME`/`DOCKHAND_PASSWORD`), or set `api_token` (or export `DOCKHAND_API_TOKEN`). For first-install bootstrap flows, set `allow_unauthenticated = true` (or `DOCKHAND_ALLOW_UNAUTHENTICATED=true`).",
 			)
 			return
 		}
@@ -183,7 +197,7 @@ func (p *dockhandProvider) Configure(ctx context.Context, req provider.Configure
 		}
 	}
 
-	client, err := NewClient(endpoint, sessionCookie, defaultEnv, insecure)
+	client, err := NewClient(endpoint, sessionCookie, authHeader, defaultEnv, insecure)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Invalid provider configuration",

--- a/internal/provider/resource_container_actions_tf_acc_test.go
+++ b/internal/provider/resource_container_actions_tf_acc_test.go
@@ -123,7 +123,7 @@ func testAccCreateContainerFixture(t *testing.T, endpoint string, username strin
 
 	ctx := context.Background()
 	sessionCookie := testAccLoginSessionCookie(t, endpoint, username, password)
-	client, err := NewClient(endpoint, sessionCookie, env, false)
+	client, err := NewClient(endpoint, sessionCookie, "", env, false)
 	if err != nil {
 		t.Fatalf("create client: %v", err)
 	}

--- a/internal/provider/resource_environment_tf_acc_test.go
+++ b/internal/provider/resource_environment_tf_acc_test.go
@@ -180,7 +180,7 @@ func testAccCheckHawserConnected(resourceName string, endpoint string, username 
 				continue
 			}
 
-			client, err := NewClient(endpoint, sessionCookie, testAccDefaultEnv(), false)
+			client, err := NewClient(endpoint, sessionCookie, "", testAccDefaultEnv(), false)
 			if err != nil {
 				lastErr = err
 				time.Sleep(3 * time.Second)

--- a/internal/provider/resource_final_action_contract_tf_acc_test.go
+++ b/internal/provider/resource_final_action_contract_tf_acc_test.go
@@ -261,7 +261,7 @@ func testAccCheckScannerAvailability(environmentResourceName string, endpoint st
 			return err
 		}
 
-		client, err := NewClient(endpoint, sessionCookie, envID, true)
+		client, err := NewClient(endpoint, sessionCookie, "", envID, true)
 		if err != nil {
 			return err
 		}
@@ -365,7 +365,7 @@ func testAccCheckRuntimeStackQuiesced(endpoint string, username string, password
 			return err
 		}
 
-		client, err := NewClient(endpoint, sessionCookie, env, true)
+		client, err := NewClient(endpoint, sessionCookie, "", env, true)
 		if err != nil {
 			return err
 		}

--- a/internal/provider/resource_git_stack_tf_acc_test.go
+++ b/internal/provider/resource_git_stack_tf_acc_test.go
@@ -83,7 +83,7 @@ func testAccCheckRuntimeStackExists(endpoint string, username string, password s
 			return err
 		}
 
-		client, err := NewClient(endpoint, sessionCookie, env, true)
+		client, err := NewClient(endpoint, sessionCookie, "", env, true)
 		if err != nil {
 			return err
 		}
@@ -112,7 +112,7 @@ func testAccCheckGitStackDestroyed(endpoint string, username string, password st
 			return err
 		}
 
-		client, err := NewClient(endpoint, sessionCookie, "", true)
+		client, err := NewClient(endpoint, sessionCookie, "", "", true)
 		if err != nil {
 			return err
 		}

--- a/internal/provider/resource_new_surfaces_tf_acc_test.go
+++ b/internal/provider/resource_new_surfaces_tf_acc_test.go
@@ -298,7 +298,7 @@ func TestAccJobDataSourceTerraform(t *testing.T) {
 	if err != nil {
 		t.Fatalf("login for job data source fixture: %v", err)
 	}
-	client, err := NewClient(endpoint, sessionCookie, defaultEnv, false)
+	client, err := NewClient(endpoint, sessionCookie, "", defaultEnv, false)
 	if err != nil {
 		t.Fatalf("new client for job data source fixture: %v", err)
 	}

--- a/internal/provider/resource_runtime_contract_tf_acc_test.go
+++ b/internal/provider/resource_runtime_contract_tf_acc_test.go
@@ -432,7 +432,7 @@ func testAccCheckContainerRuntimeEventually(endpoint string, username string, pa
 		if err != nil {
 			return err
 		}
-		client, err := NewClient(endpoint, sessionCookie, env, true)
+		client, err := NewClient(endpoint, sessionCookie, "", env, true)
 		if err != nil {
 			return err
 		}

--- a/internal/provider/resource_schedule_webhook_contract_tf_acc_test.go
+++ b/internal/provider/resource_schedule_webhook_contract_tf_acc_test.go
@@ -92,7 +92,7 @@ func testAccScheduleFixture(t *testing.T, endpoint string, username string, pass
 	t.Helper()
 
 	sessionCookie := testAccLoginSessionCookie(t, endpoint, username, password)
-	client, err := NewClient(endpoint, sessionCookie, testAccDefaultEnv(), true)
+	client, err := NewClient(endpoint, sessionCookie, "", testAccDefaultEnv(), true)
 	if err != nil {
 		t.Fatalf("new client: %v", err)
 	}

--- a/internal/provider/resource_settings_contract_tf_acc_test.go
+++ b/internal/provider/resource_settings_contract_tf_acc_test.go
@@ -406,7 +406,7 @@ func testAccDestroyClient(endpoint string, username string, password string) (*C
 	if err != nil {
 		return nil, err
 	}
-	return NewClient(endpoint, sessionCookie, testAccDefaultEnv(), true)
+	return NewClient(endpoint, sessionCookie, "", testAccDefaultEnv(), true)
 }
 
 func testAccSettingsSingletonsConfig(timeFormat string, dateFormat string, showStopped bool, highlight bool, timezone string, sessionTimeout int64, primaryStackLocation *string, externalStackPaths []string) string {

--- a/internal/provider/resource_user_acc_test.go
+++ b/internal/provider/resource_user_acc_test.go
@@ -9,7 +9,7 @@ func TestAccUserResource(t *testing.T) {
 	endpoint, username, password := testAccEnv(t)
 	sessionCookie := testAccLoginSessionCookie(t, endpoint, username, password)
 
-	client, err := NewClient(endpoint, sessionCookie, "1", true)
+	client, err := NewClient(endpoint, sessionCookie, "", "1", true)
 	if err != nil {
 		t.Fatalf("new client: %v", err)
 	}

--- a/internal/provider/resource_user_tf_acc_test.go
+++ b/internal/provider/resource_user_tf_acc_test.go
@@ -87,7 +87,7 @@ func testAccCheckUserDestroyed(endpoint string, username string, password string
 		if err != nil {
 			return err
 		}
-		client, err := NewClient(endpoint, sessionCookie, "1", true)
+		client, err := NewClient(endpoint, sessionCookie, "", "1", true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## What changed
- Added `api_token` provider configuration and `DOCKHAND_API_TOKEN` support.
- Switched provider requests to send either the existing session cookie or a bearer auth header.
- Updated docs and client tests to cover the new auth mode.

## Why
Issue #99 requested support for Dockhand API tokens in place of username/password login.

## Validation
- `go test ./internal/provider`
- `./scripts/verify.sh --quality`

Closes #99
