### PR TITLE
ci: normalize manual release version input

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -46,6 +46,7 @@ jobs:
           set -euo pipefail
           if [[ -n "${{ inputs.version }}" ]]; then
             v="${{ inputs.version }}"
+            v="${v#v}"
           else
             # refs/tags/vX.Y.Z -> X.Y.Z
             ref="${GITHUB_REF#refs/tags/}"


### PR DESCRIPTION
Fixes #102

## Summary
- strip an optional leading v from workflow_dispatch release inputs
- prevent accidental vv-prefixed tags/releases from manual release runs
- keep tag-derived release behavior unchanged

## Why
Terraform Registry metadata for 0.1.74 currently points at a malformed vv0.1.74 release path due to a manual release input including a leading v. This change prevents that class of publishing error from recurring.