### PR TITLE
test: track /api/auth/tokens in endpoint probe

### DIFF
--- a/scripts/endpoint-probe.py
+++ b/scripts/endpoint-probe.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, List, Optional, Tuple
 ENDPOINTS: List[Dict[str, Any]] = [
     {"method": "POST", "path": "/api/auth/login"},
     {"method": "GET", "path": "/api/auth/session"},
+    {"method": "GET", "path": "/api/auth/tokens"},
+    {"method": "POST", "path": "/api/auth/tokens"},
     {"method": "GET", "path": "/api/settings/general"},
     {"method": "POST", "path": "/api/settings/general"},
     {"method": "GET", "path": "/api/auth/settings"},


### PR DESCRIPTION
## Summary
- add /api/auth/tokens GET and POST probe entries
- close drift gap detected in latest compatibility run

Fixes #108

## Validation
- ./scripts/verify.sh --quality
- /usr/bin/python3 scripts/api-drift-gate.py
