### PR TITLE
fix(provider): defer unknown endpoint and retry login

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The provider supports Dockhand's login-based authentication flow and bearer-toke
 - Optional MFA: `mfa_token`
 - Optional provider selection: `auth_provider`
 - First-install bootstrap: `allow_unauthenticated = true`
+- Computed endpoints: when `endpoint` references another resource's output, plan defers provider configuration until apply; login retries transient connection failures
 
 Bootstrap example for a fresh Dockhand instance with no auth configured yet:
 

--- a/docs/api-matrix.md
+++ b/docs/api-matrix.md
@@ -20,7 +20,7 @@ Live verification artifacts:
 
 | Terraform Surface | API Input | Notes | Status |
 | --- | --- | --- | --- |
-| `provider.dockhand.endpoint` | Base URL | Supports `DOCKHAND_ENDPOINT`. | implemented |
+| `provider.dockhand.endpoint` | Base URL | Supports `DOCKHAND_ENDPOINT`. Defers provider configuration during plan when the endpoint value is unknown (for example when it references another resource's computed attribute). Login retries transient connection failures during apply. | implemented |
 | `provider.dockhand.username` | Username | Supports `DOCKHAND_USERNAME`. | implemented |
 | `provider.dockhand.password` | Password | Supports `DOCKHAND_PASSWORD`. | implemented |
 | `provider.dockhand.api_token` | API token | Supports `DOCKHAND_API_TOKEN`; used as bearer-token auth. | implemented |

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,21 @@ resource "dockhand_user" "admin" {
 }
 ```
 
+When `endpoint` references another resource's computed attribute (for example a VM IP created in the same apply), the provider defers configuration during `terraform plan` and connects during apply. Login retries transient connection failures while Dockhand becomes reachable:
+
+```terraform
+provider "dockhand" {
+  endpoint              = example_vm.dockhand.ip_address
+  allow_unauthenticated = true
+}
+
+resource "dockhand_user" "initial_admin" {
+  username = "admin"
+  password = var.initial_admin_password
+  is_admin = true
+}
+```
+
 ## Recommended Starting Points
 
 - Bootstrap first admin: `examples/scenarios/bootstrap-admin/main.tf`

--- a/internal/provider/auth.go
+++ b/internal/provider/auth.go
@@ -5,13 +5,17 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 )
+
+const defaultLoginRetryAttempts = 6
 
 type loginResponse struct {
 	Success     bool   `json:"success"`
@@ -21,6 +25,32 @@ type loginResponse struct {
 
 // Login authenticates with Dockhand and returns a Cookie header value like "dockhand_session=...".
 func Login(ctx context.Context, endpoint string, username string, password string, mfaToken string, provider string, insecure bool) (string, error) {
+	return loginWithRetry(ctx, endpoint, username, password, mfaToken, provider, insecure, defaultLoginRetryAttempts)
+}
+
+func loginWithRetry(ctx context.Context, endpoint string, username string, password string, mfaToken string, provider string, insecure bool, attempts int) (string, error) {
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		cookie, err := loginOnce(ctx, endpoint, username, password, mfaToken, provider, insecure)
+		if err == nil {
+			return cookie, nil
+		}
+		lastErr = err
+		if !isLoginRetryable(err) || attempt == attempts-1 {
+			return "", err
+		}
+		if sleepErr := sleepLoginBackoff(ctx, attempt); sleepErr != nil {
+			return "", sleepErr
+		}
+	}
+	return "", lastErr
+}
+
+func loginOnce(ctx context.Context, endpoint string, username string, password string, mfaToken string, provider string, insecure bool) (string, error) {
 	if endpoint == "" {
 		return "", fmt.Errorf("endpoint is required")
 	}
@@ -80,11 +110,7 @@ func Login(ctx context.Context, endpoint string, username string, password strin
 
 	b, _ := io.ReadAll(res.Body)
 	if res.StatusCode < 200 || res.StatusCode > 299 {
-		var lr loginResponse
-		if err := json.Unmarshal(b, &lr); err == nil && lr.Error != "" {
-			return "", fmt.Errorf("dockhand login failed: %s", lr.Error)
-		}
-		return "", fmt.Errorf("dockhand login failed (status %d): %s", res.StatusCode, strings.TrimSpace(string(b)))
+		return "", loginHTTPError(res.StatusCode, b)
 	}
 
 	for _, c := range res.Cookies() {
@@ -102,4 +128,84 @@ func Login(ctx context.Context, endpoint string, username string, password strin
 	}
 
 	return "", fmt.Errorf("dockhand login succeeded but no dockhand_session cookie was returned")
+}
+
+func loginHTTPError(status int, body []byte) error {
+	var lr loginResponse
+	if err := json.Unmarshal(body, &lr); err == nil && lr.Error != "" {
+		return fmt.Errorf("dockhand login failed: %s", lr.Error)
+	}
+	return fmt.Errorf("dockhand login failed (status %d): %s", status, strings.TrimSpace(string(body)))
+}
+
+func isLoginHTTPRetryable(status int) bool {
+	switch status {
+	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func isLoginRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "connection refused"),
+		strings.Contains(msg, "connection reset"),
+		strings.Contains(msg, "broken pipe"),
+		strings.Contains(msg, "no route to host"),
+		strings.Contains(msg, "eof"),
+		strings.Contains(msg, "timeout"),
+		strings.Contains(msg, "temporarily unavailable"):
+		return true
+	}
+
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+
+	return isLoginHTTPRetryable(extractLoginHTTPStatus(err))
+}
+
+func extractLoginHTTPStatus(err error) int {
+	msg := err.Error()
+	if !strings.Contains(msg, "status ") {
+		return 0
+	}
+	var status int
+	if _, scanErr := fmt.Sscanf(msg, "dockhand login failed (status %d)", &status); scanErr == nil {
+		return status
+	}
+	return 0
+}
+
+func sleepLoginBackoff(ctx context.Context, attempt int) error {
+	delays := []time.Duration{
+		500 * time.Millisecond,
+		1 * time.Second,
+		2 * time.Second,
+		3 * time.Second,
+		5 * time.Second,
+	}
+	delay := delays[len(delays)-1]
+	if attempt >= 0 && attempt < len(delays) {
+		delay = delays[attempt]
+	}
+
+	t := time.NewTimer(delay)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
 }

--- a/internal/provider/auth_test.go
+++ b/internal/provider/auth_test.go
@@ -59,7 +59,13 @@ func TestLoginRetriesTransientHTTPFailures(t *testing.T) {
 			http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
 			return
 		}
-		http.SetCookie(w, &http.Cookie{Name: "dockhand_session", Value: "session-token"})
+		http.SetCookie(w, &http.Cookie{
+			Name:     "dockhand_session",
+			Value:    "session-token",
+			HttpOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
+		})
 		_ = json.NewEncoder(w).Encode(loginResponse{Success: true})
 	}))
 	defer server.Close()

--- a/internal/provider/auth_test.go
+++ b/internal/provider/auth_test.go
@@ -1,0 +1,120 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestProviderEndpointValueUsesConfig(t *testing.T) {
+	t.Setenv("DOCKHAND_ENDPOINT", "https://env.example")
+
+	cfg := dockhandProviderModel{
+		Endpoint: types.StringValue("https://config.example"),
+	}
+	if got := providerEndpointValue(cfg); got != "https://config.example" {
+		t.Fatalf("expected config endpoint, got %q", got)
+	}
+}
+
+func TestProviderEndpointValueUsesEnvWhenUnset(t *testing.T) {
+	t.Setenv("DOCKHAND_ENDPOINT", "https://env.example")
+
+	cfg := dockhandProviderModel{
+		Endpoint: types.StringNull(),
+	}
+	if got := providerEndpointValue(cfg); got != "https://env.example" {
+		t.Fatalf("expected env endpoint, got %q", got)
+	}
+}
+
+func TestProviderEndpointDeferredWhenUnknown(t *testing.T) {
+	cfg := dockhandProviderModel{
+		Endpoint: types.StringUnknown(),
+	}
+	if !providerEndpointDeferred(cfg) {
+		t.Fatal("expected unknown endpoint to defer provider configuration")
+	}
+}
+
+func TestProviderEndpointNotDeferredWhenKnown(t *testing.T) {
+	cfg := dockhandProviderModel{
+		Endpoint: types.StringValue("https://dockhand.example"),
+	}
+	if providerEndpointDeferred(cfg) {
+		t.Fatal("expected known endpoint not to defer provider configuration")
+	}
+}
+
+func TestLoginRetriesTransientHTTPFailures(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		http.SetCookie(w, &http.Cookie{Name: "dockhand_session", Value: "session-token"})
+		_ = json.NewEncoder(w).Encode(loginResponse{Success: true})
+	}))
+	defer server.Close()
+
+	cookie, err := loginWithRetry(context.Background(), server.URL, "admin", "password", "", "local", false, 6)
+	if err != nil {
+		t.Fatalf("loginWithRetry returned error: %v", err)
+	}
+	if cookie != "dockhand_session=session-token" {
+		t.Fatalf("unexpected cookie: %q", cookie)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 login attempts, got %d", attempts)
+	}
+}
+
+func TestLoginDoesNotRetryAuthFailures(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(loginResponse{Success: false, Error: "invalid credentials"})
+	}))
+	defer server.Close()
+
+	_, err := loginWithRetry(context.Background(), server.URL, "admin", "wrong", "", "local", false, 6)
+	if err == nil {
+		t.Fatal("expected login error")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected single login attempt for auth failure, got %d", attempts)
+	}
+}
+
+func TestIsLoginRetryableConnectionErrors(t *testing.T) {
+	cases := []string{
+		"dial tcp 127.0.0.1:443: connect: connection refused",
+		"read tcp: connection reset by peer",
+		"dockhand login failed (status 503): unavailable",
+	}
+	for _, msg := range cases {
+		if !isLoginRetryable(&retryableError{msg: msg}) {
+			t.Fatalf("expected retryable error for %q", msg)
+		}
+	}
+	if isLoginRetryable(context.Canceled) {
+		t.Fatal("expected context.Canceled not to retry")
+	}
+	if isLoginRetryable(fmt.Errorf("dockhand login failed: invalid credentials")) {
+		t.Fatal("expected auth failure not to retry")
+	}
+}
+
+type retryableError struct {
+	msg string
+}
+
+func (e *retryableError) Error() string { return e.msg }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -47,7 +47,7 @@ func (p *dockhandProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"endpoint": schema.StringAttribute{
-				MarkdownDescription: "Dockhand API base URL. Can also be set with `DOCKHAND_ENDPOINT`.",
+				MarkdownDescription: "Dockhand API base URL. Can also be set with `DOCKHAND_ENDPOINT`. When this value is unknown during plan (for example when it references another resource's computed attribute), provider configuration is deferred until apply.",
 				Optional:            true,
 			},
 			"username": schema.StringAttribute{
@@ -96,9 +96,9 @@ func (p *dockhandProvider) Configure(ctx context.Context, req provider.Configure
 		return
 	}
 
-	endpoint := os.Getenv("DOCKHAND_ENDPOINT")
-	if !config.Endpoint.IsNull() && !config.Endpoint.IsUnknown() {
-		endpoint = config.Endpoint.ValueString()
+	endpoint := providerEndpointValue(config)
+	if providerEndpointDeferred(config) {
+		return
 	}
 
 	username := os.Getenv("DOCKHAND_USERNAME")

--- a/internal/provider/provider_config.go
+++ b/internal/provider/provider_config.go
@@ -1,0 +1,18 @@
+package provider
+
+import (
+	"os"
+	"strings"
+)
+
+func providerEndpointValue(config dockhandProviderModel) string {
+	endpoint := os.Getenv("DOCKHAND_ENDPOINT")
+	if !config.Endpoint.IsNull() && !config.Endpoint.IsUnknown() {
+		endpoint = config.Endpoint.ValueString()
+	}
+	return strings.TrimSpace(endpoint)
+}
+
+func providerEndpointDeferred(config dockhandProviderModel) bool {
+	return config.Endpoint.IsUnknown()
+}

--- a/internal/provider/provider_config_test.go
+++ b/internal/provider/provider_config_test.go
@@ -1,0 +1,16 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestProviderEndpointValueTrimsWhitespace(t *testing.T) {
+	cfg := dockhandProviderModel{
+		Endpoint: types.StringValue("  https://dockhand.example  "),
+	}
+	if got := providerEndpointValue(cfg); got != "https://dockhand.example" {
+		t.Fatalf("expected trimmed endpoint, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Defer provider configuration during `terraform plan` when `endpoint` is unknown (for example when it references another resource's computed attribute).
- Retry transient Dockhand login failures during apply while the endpoint becomes reachable.
- Add unit tests and document bootstrap patterns for computed endpoints.

Fixes #117.

## Test plan
- [x] `go test ./internal/provider -run 'TestProviderEndpoint|TestLogin|TestIsLogin'`
- [x] `./scripts/verify.sh --quality`
- [ ] Release `v0.1.81` after merge


Made with [Cursor](https://cursor.com)