### PR TITLE
fix: bootstrap API retry and git SSH credential payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The provider supports Dockhand's login-based authentication flow and bearer-toke
 - Optional MFA: `mfa_token`
 - Optional provider selection: `auth_provider`
 - First-install bootstrap: `allow_unauthenticated = true`
-- Computed endpoints: when `endpoint` references another resource's output, plan defers provider configuration until apply; login retries transient connection failures
+- Computed endpoints: when `endpoint` references another resource's output, plan defers provider configuration until apply; login and API requests retry transient connection failures (configurable via `request_retry_*`)
 
 Bootstrap example for a fresh Dockhand instance with no auth configured yet:
 
@@ -181,6 +181,9 @@ Provider arguments:
 - `default_env` — default environment ID for resources that omit `env`
 - `insecure` — disable TLS verification
 - `allow_unauthenticated` — permit bootstrap flows before auth is configured
+- `request_retry_attempts` — max attempts for login/API requests on transient connection failures (default `6`)
+- `request_retry_min_seconds` — minimum wait between retries in seconds (default `1`)
+- `request_retry_max_seconds` — maximum wait between retries in seconds (default `5`)
 
 Environment variable fallbacks:
 
@@ -192,6 +195,9 @@ Environment variable fallbacks:
 - `DOCKHAND_AUTH_PROVIDER`
 - `DOCKHAND_DEFAULT_ENV`
 - `DOCKHAND_ALLOW_UNAUTHENTICATED`
+- `DOCKHAND_REQUEST_RETRY_ATTEMPTS`
+- `DOCKHAND_REQUEST_RETRY_MIN_SECONDS`
+- `DOCKHAND_REQUEST_RETRY_MAX_SECONDS`
 
 ## Additional Repository Policy
 

--- a/docs/api-matrix.md
+++ b/docs/api-matrix.md
@@ -20,7 +20,7 @@ Live verification artifacts:
 
 | Terraform Surface | API Input | Notes | Status |
 | --- | --- | --- | --- |
-| `provider.dockhand.endpoint` | Base URL | Supports `DOCKHAND_ENDPOINT`. Defers provider configuration during plan when the endpoint value is unknown (for example when it references another resource's computed attribute). Login retries transient connection failures during apply. | implemented |
+| `provider.dockhand.endpoint` | Base URL | Supports `DOCKHAND_ENDPOINT`. Defers provider configuration during plan when the endpoint value is unknown (for example when it references another resource's computed attribute). Retries transient connection failures during apply for login and API requests. | implemented |
 | `provider.dockhand.username` | Username | Supports `DOCKHAND_USERNAME`. | implemented |
 | `provider.dockhand.password` | Password | Supports `DOCKHAND_PASSWORD`. | implemented |
 | `provider.dockhand.api_token` | API token | Supports `DOCKHAND_API_TOKEN`; used as bearer-token auth. | implemented |
@@ -29,6 +29,9 @@ Live verification artifacts:
 | `provider.dockhand.default_env` | `env` query default | Supports `DOCKHAND_DEFAULT_ENV`. | implemented |
 | `provider.dockhand.insecure` | TLS behavior | Disables TLS verification for development. | implemented |
 | `provider.dockhand.allow_unauthenticated` | Bootstrap mode | Supports `DOCKHAND_ALLOW_UNAUTHENTICATED`; allows initialization without login credentials for first-install bootstrap flows. | implemented |
+| `provider.dockhand.request_retry_attempts` | Retry policy | Supports `DOCKHAND_REQUEST_RETRY_ATTEMPTS`; max attempts for login/API requests on transient connection failures (default `6`). | implemented |
+| `provider.dockhand.request_retry_min_seconds` | Retry policy | Supports `DOCKHAND_REQUEST_RETRY_MIN_SECONDS`; minimum wait between retries in seconds (default `1`). | implemented |
+| `provider.dockhand.request_retry_max_seconds` | Retry policy | Supports `DOCKHAND_REQUEST_RETRY_MAX_SECONDS`; maximum wait between retries in seconds (default `5`). | implemented |
 
 ## Resources
 
@@ -56,9 +59,9 @@ Live verification artifacts:
 | `dockhand_registry` | Update | `PUT /api/registries/{id}` | Omitting username/password preserves credentials. | implemented |
 | `dockhand_registry` | Delete | `DELETE /api/registries/{id}` | `404` treated as already deleted. | implemented |
 | `dockhand_registry_image_delete_action` | Delete remote image tag | `DELETE /api/registry/image` | One-shot remote registry delete action for (`registry`,`image`,`tag`) tuples. | implemented |
-| `dockhand_git_credential` | Create | `POST /api/git/credentials` | Observed payload supports name/authType/username/password. | partial |
+| `dockhand_git_credential` | Create | `POST /api/git/credentials` | Supports `password` and `ssh` auth types. SSH keys are sent as `sshPrivateKey`. | implemented |
 | `dockhand_git_credential` | Read | `GET /api/git/credentials/{id}` | `404` removes from state. | implemented |
-| `dockhand_git_credential` | Update | `PUT /api/git/credentials/{id}` | Password is write-only. | partial |
+| `dockhand_git_credential` | Update | `PUT /api/git/credentials/{id}` | Password and SSH key are write-only. | implemented |
 | `dockhand_git_credential` | Delete | `DELETE /api/git/credentials/{id}` | `404` treated as already deleted. | implemented |
 | `dockhand_git_repository` | Create | `POST /api/git/repositories` | Observed payload supports name/url/branch/composePath/credentialId/etc. | partial |
 | `dockhand_git_repository` | Read | `GET /api/git/repositories/{id}` | `404` removes from state. | implemented |

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ resource "dockhand_user" "admin" {
 }
 ```
 
-When `endpoint` references another resource's computed attribute (for example a VM IP created in the same apply), the provider defers configuration during `terraform plan` and connects during apply. Login retries transient connection failures while Dockhand becomes reachable:
+When `endpoint` references another resource's computed attribute (for example a VM IP created in the same apply), the provider defers configuration during `terraform plan` and connects during apply. Login and API requests retry transient connection failures while Dockhand becomes reachable. Tune retry behavior with `request_retry_attempts`, `request_retry_min_seconds`, and `request_retry_max_seconds`.
 
 ```terraform
 provider "dockhand" {
@@ -195,3 +195,6 @@ resource "dockhand_user" "initial_admin" {
 - `default_env` (String) Default environment ID used when resources omit `env`. Can also be set with `DOCKHAND_DEFAULT_ENV`.
 - `insecure` (Boolean) Disable TLS verification.
 - `allow_unauthenticated` (Boolean) Allow provider initialization without login credentials for first-install bootstrap flows. Can also be set with `DOCKHAND_ALLOW_UNAUTHENTICATED`.
+- `request_retry_attempts` (Number) Maximum attempts for login/API requests on transient connection failures. Default `6`. Can also be set with `DOCKHAND_REQUEST_RETRY_ATTEMPTS`.
+- `request_retry_min_seconds` (Number) Minimum wait between retry attempts in seconds. Default `1`. Can also be set with `DOCKHAND_REQUEST_RETRY_MIN_SECONDS`.
+- `request_retry_max_seconds` (Number) Maximum wait between retry attempts in seconds. Default `5`. Can also be set with `DOCKHAND_REQUEST_RETRY_MAX_SECONDS`.

--- a/docs/resources/git_credential.md
+++ b/docs/resources/git_credential.md
@@ -20,6 +20,18 @@ resource "dockhand_git_credential" "github" {
 
 If you are managing an existing credential and do not want to rotate the stored secret, omit `password` (Dockhand will keep the existing one).
 
+SSH key credential:
+
+```terraform
+resource "dockhand_git_credential" "deploy_key" {
+  name      = "deploy_key"
+  auth_type = "ssh"
+  ssh_key   = file("~/.ssh/id_ed25519")
+}
+```
+
+The provider sends the key to Dockhand as `sshPrivateKey`.
+
 ## Schema
 
 ### Read-only

--- a/internal/provider/auth.go
+++ b/internal/provider/auth.go
@@ -5,17 +5,13 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 )
-
-const defaultLoginRetryAttempts = 6
 
 type loginResponse struct {
 	Success     bool   `json:"success"`
@@ -24,14 +20,12 @@ type loginResponse struct {
 }
 
 // Login authenticates with Dockhand and returns a Cookie header value like "dockhand_session=...".
-func Login(ctx context.Context, endpoint string, username string, password string, mfaToken string, provider string, insecure bool) (string, error) {
-	return loginWithRetry(ctx, endpoint, username, password, mfaToken, provider, insecure, defaultLoginRetryAttempts)
+func Login(ctx context.Context, endpoint string, username string, password string, mfaToken string, provider string, insecure bool, retry requestRetryConfig) (string, error) {
+	return loginWithRetry(ctx, endpoint, username, password, mfaToken, provider, insecure, retry)
 }
 
-func loginWithRetry(ctx context.Context, endpoint string, username string, password string, mfaToken string, provider string, insecure bool, attempts int) (string, error) {
-	if attempts < 1 {
-		attempts = 1
-	}
+func loginWithRetry(ctx context.Context, endpoint string, username string, password string, mfaToken string, provider string, insecure bool, retry requestRetryConfig) (string, error) {
+	attempts := retry.attemptsOrDefault()
 
 	var lastErr error
 	for attempt := 0; attempt < attempts; attempt++ {
@@ -43,7 +37,7 @@ func loginWithRetry(ctx context.Context, endpoint string, username string, passw
 		if !isLoginRetryable(err) || attempt == attempts-1 {
 			return "", err
 		}
-		if sleepErr := sleepLoginBackoff(ctx, attempt); sleepErr != nil {
+		if sleepErr := retry.sleep(ctx, attempt); sleepErr != nil {
 			return "", sleepErr
 		}
 	}
@@ -138,74 +132,18 @@ func loginHTTPError(status int, body []byte) error {
 	return fmt.Errorf("dockhand login failed (status %d): %s", status, strings.TrimSpace(string(body)))
 }
 
+func isLoginRetryable(err error) bool {
+	if isTransientNetworkError(err) {
+		return true
+	}
+	return isLoginHTTPRetryable(extractHTTPStatusFromError(err))
+}
+
 func isLoginHTTPRetryable(status int) bool {
 	switch status {
 	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
 		return true
 	default:
 		return false
-	}
-}
-
-func isLoginRetryable(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return false
-	}
-
-	msg := strings.ToLower(err.Error())
-	switch {
-	case strings.Contains(msg, "connection refused"),
-		strings.Contains(msg, "connection reset"),
-		strings.Contains(msg, "broken pipe"),
-		strings.Contains(msg, "no route to host"),
-		strings.Contains(msg, "eof"),
-		strings.Contains(msg, "timeout"),
-		strings.Contains(msg, "temporarily unavailable"):
-		return true
-	}
-
-	var ne net.Error
-	if errors.As(err, &ne) && ne.Timeout() {
-		return true
-	}
-
-	return isLoginHTTPRetryable(extractLoginHTTPStatus(err))
-}
-
-func extractLoginHTTPStatus(err error) int {
-	msg := err.Error()
-	if !strings.Contains(msg, "status ") {
-		return 0
-	}
-	var status int
-	if _, scanErr := fmt.Sscanf(msg, "dockhand login failed (status %d)", &status); scanErr == nil {
-		return status
-	}
-	return 0
-}
-
-func sleepLoginBackoff(ctx context.Context, attempt int) error {
-	delays := []time.Duration{
-		500 * time.Millisecond,
-		1 * time.Second,
-		2 * time.Second,
-		3 * time.Second,
-		5 * time.Second,
-	}
-	delay := delays[len(delays)-1]
-	if attempt >= 0 && attempt < len(delays) {
-		delay = delays[attempt]
-	}
-
-	t := time.NewTimer(delay)
-	defer t.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-t.C:
-		return nil
 	}
 }

--- a/internal/provider/auth_test.go
+++ b/internal/provider/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -70,7 +71,7 @@ func TestLoginRetriesTransientHTTPFailures(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cookie, err := loginWithRetry(context.Background(), server.URL, "admin", "password", "", "local", false, 6)
+	cookie, err := loginWithRetry(context.Background(), server.URL, "admin", "password", "", "local", false, requestRetryConfig{attempts: 6, minDelay: time.Millisecond, maxDelay: time.Millisecond})
 	if err != nil {
 		t.Fatalf("loginWithRetry returned error: %v", err)
 	}
@@ -91,7 +92,7 @@ func TestLoginDoesNotRetryAuthFailures(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := loginWithRetry(context.Background(), server.URL, "admin", "wrong", "", "local", false, 6)
+	_, err := loginWithRetry(context.Background(), server.URL, "admin", "wrong", "", "local", false, requestRetryConfig{attempts: 6, minDelay: time.Millisecond, maxDelay: time.Millisecond})
 	if err == nil {
 		t.Fatal("expected login error")
 	}

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -18,11 +18,14 @@ import (
 )
 
 type Client struct {
-	baseURL       *url.URL
-	httpClient    *http.Client
-	sessionCookie string
-	authHeader    string
-	defaultEnv    string
+	baseURL              *url.URL
+	httpClient           *http.Client
+	sessionCookie        string
+	authHeader           string
+	defaultEnv           string
+	requestRetryAttempts int
+	requestRetryMinDelay time.Duration
+	requestRetryMaxDelay time.Duration
 }
 
 type stackPayload struct {
@@ -294,7 +297,7 @@ type gitCredentialPayload struct {
 	AuthType string  `json:"authType"`
 	Username *string `json:"username,omitempty"`
 	Password *string `json:"password,omitempty"`
-	SSHKey   *string `json:"sshKey,omitempty"`
+	SSHKey   *string `json:"sshPrivateKey,omitempty"`
 }
 
 type gitCredentialResponse struct {
@@ -956,10 +959,37 @@ func NewClient(endpoint string, sessionCookie string, authHeader string, default
 			Timeout:   30 * time.Second,
 			Transport: transport,
 		},
-		sessionCookie: sessionCookie,
-		authHeader:    authHeader,
-		defaultEnv:    defaultEnv,
+		sessionCookie:        sessionCookie,
+		authHeader:           authHeader,
+		defaultEnv:           defaultEnv,
+		requestRetryAttempts: defaultRequestRetryAttempts,
+		requestRetryMinDelay: defaultRequestRetryMinDelay,
+		requestRetryMaxDelay: defaultRequestRetryMaxDelay,
 	}, nil
+}
+
+func (c *Client) SetRequestRetryPolicy(retry requestRetryConfig) {
+	if c == nil {
+		return
+	}
+	if retry.attempts > 0 {
+		c.requestRetryAttempts = retry.attempts
+	}
+	if retry.minDelay > 0 {
+		c.requestRetryMinDelay = retry.minDelay
+	}
+	if retry.maxDelay > 0 {
+		c.requestRetryMaxDelay = retry.maxDelay
+	}
+}
+
+func (c *Client) requestRetrySleep(ctx context.Context, attempt int) error {
+	retry := requestRetryConfig{
+		attempts: c.requestRetryAttempts,
+		minDelay: c.requestRetryMinDelay,
+		maxDelay: c.requestRetryMaxDelay,
+	}
+	return retry.sleep(ctx, attempt)
 }
 
 func (c *Client) GetGeneralSettings(ctx context.Context) (*generalSettings, int, error) {
@@ -2830,8 +2860,12 @@ func (c *Client) doJSONWithStatusUsingClient(ctx context.Context, httpClient *ht
 
 	var lastStatus int
 	var responseBody []byte
+	maxAttempts := c.requestRetryAttempts
+	if maxAttempts < 1 {
+		maxAttempts = defaultRequestRetryAttempts
+	}
 
-	for attempt := 0; attempt < 3; attempt++ {
+	for attempt := 0; attempt < maxAttempts; attempt++ {
 		var body io.Reader
 		if payloadBytes != nil {
 			body = bytes.NewReader(payloadBytes)
@@ -2851,8 +2885,8 @@ func (c *Client) doJSONWithStatusUsingClient(ctx context.Context, httpClient *ht
 		//nolint:gosec // Provider endpoint is an explicit user-configured Dockhand API target.
 		res, err := httpClient.Do(req)
 		if err != nil {
-			if shouldRetry(method, 0, err) && attempt < 2 {
-				if sleepErr := sleepBackoff(ctx, attempt); sleepErr != nil {
+			if shouldRetryRequest(method, 0, err) && attempt < maxAttempts-1 {
+				if sleepErr := c.requestRetrySleep(ctx, attempt); sleepErr != nil {
 					return 0, err
 				}
 				continue
@@ -2871,8 +2905,8 @@ func (c *Client) doJSONWithStatusUsingClient(ctx context.Context, httpClient *ht
 		responseBody, err = io.ReadAll(io.LimitReader(res.Body, limit))
 		res.Body.Close()
 		if err != nil {
-			if shouldRetry(method, lastStatus, err) && attempt < 2 {
-				if sleepErr := sleepBackoff(ctx, attempt); sleepErr != nil {
+			if shouldRetryRequest(method, lastStatus, err) && attempt < maxAttempts-1 {
+				if sleepErr := c.requestRetrySleep(ctx, attempt); sleepErr != nil {
 					return lastStatus, err
 				}
 				continue
@@ -2880,8 +2914,8 @@ func (c *Client) doJSONWithStatusUsingClient(ctx context.Context, httpClient *ht
 			return lastStatus, err
 		}
 
-		if shouldRetry(method, lastStatus, nil) && attempt < 2 {
-			if sleepErr := sleepBackoff(ctx, attempt); sleepErr != nil {
+		if shouldRetryRequest(method, lastStatus, nil) && attempt < maxAttempts-1 {
+			if sleepErr := c.requestRetrySleep(ctx, attempt); sleepErr != nil {
 				break
 			}
 			continue
@@ -2941,49 +2975,6 @@ func parseStacks(raw json.RawMessage) ([]stackResponse, error) {
 	}
 
 	return nil, fmt.Errorf("unexpected stack list response shape")
-}
-
-func shouldRetry(method string, status int, err error) bool {
-	switch method {
-	case http.MethodGet, http.MethodDelete:
-	default:
-		return false
-	}
-
-	if err != nil {
-		// Don't retry if the context is already cancelled.
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return false
-		}
-		var ne net.Error
-		if errors.As(err, &ne) && ne.Timeout() {
-			return true
-		}
-		// Retry other transient network errors (e.g. connection reset).
-		return true
-	}
-
-	switch status {
-	case 429, 502, 503, 504:
-		return true
-	default:
-		return false
-	}
-}
-
-func sleepBackoff(ctx context.Context, attempt int) error {
-	delay := 200 * time.Millisecond
-	if attempt == 1 {
-		delay = 500 * time.Millisecond
-	}
-	t := time.NewTimer(delay)
-	defer t.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-t.C:
-		return nil
-	}
 }
 
 func sleepBackoffWithInterval(ctx context.Context, delay time.Duration) error {

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -1,10 +1,12 @@
 package provider
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewClientAllowsEmptySessionCookie(t *testing.T) {
@@ -51,6 +53,42 @@ func TestClientUsesBearerTokenAuthHeader(t *testing.T) {
 	}
 	if gotAuth != "Bearer test-token" {
 		t.Fatalf("expected bearer auth header, got %q", gotAuth)
+	}
+}
+
+func TestClientRetriesPOSTOnConnectionRefused(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	client, err := NewClient("http://example.com", "", "", "1", true)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	client.SetRequestRetryPolicy(requestRetryConfig{
+		attempts: 3,
+		minDelay: time.Millisecond,
+		maxDelay: time.Millisecond,
+	})
+
+	client.httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, fmt.Errorf("dial tcp 127.0.0.1:80: connect: connection refused")
+		}
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       io.NopCloser(strings.NewReader(`{"id":1,"username":"admin"}`)),
+			Header:     make(http.Header),
+			Request:    r,
+		}, nil
+	})
+
+	var out userResponse
+	if _, err := client.doJSONWithStatus(t.Context(), http.MethodPost, "/api/users", nil, map[string]any{"username": "admin"}, &out); err != nil {
+		t.Fatalf("expected POST retry to succeed, got: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -27,15 +27,18 @@ type dockhandProvider struct {
 }
 
 type dockhandProviderModel struct {
-	Endpoint             types.String `tfsdk:"endpoint"`
-	Username             types.String `tfsdk:"username"`
-	Password             types.String `tfsdk:"password"`
-	APIToken             types.String `tfsdk:"api_token"`
-	MFAToken             types.String `tfsdk:"mfa_token"`
-	AuthProvider         types.String `tfsdk:"auth_provider"`
-	DefaultEnv           types.String `tfsdk:"default_env"`
-	Insecure             types.Bool   `tfsdk:"insecure"`
-	AllowUnauthenticated types.Bool   `tfsdk:"allow_unauthenticated"`
+	Endpoint               types.String `tfsdk:"endpoint"`
+	Username               types.String `tfsdk:"username"`
+	Password               types.String `tfsdk:"password"`
+	APIToken               types.String `tfsdk:"api_token"`
+	MFAToken               types.String `tfsdk:"mfa_token"`
+	AuthProvider           types.String `tfsdk:"auth_provider"`
+	DefaultEnv             types.String `tfsdk:"default_env"`
+	Insecure               types.Bool   `tfsdk:"insecure"`
+	AllowUnauthenticated   types.Bool   `tfsdk:"allow_unauthenticated"`
+	RequestRetryAttempts   types.Int64  `tfsdk:"request_retry_attempts"`
+	RequestRetryMinSeconds types.Int64  `tfsdk:"request_retry_min_seconds"`
+	RequestRetryMaxSeconds types.Int64  `tfsdk:"request_retry_max_seconds"`
 }
 
 func (p *dockhandProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -83,6 +86,18 @@ func (p *dockhandProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 			},
 			"allow_unauthenticated": schema.BoolAttribute{
 				MarkdownDescription: "Allow provider initialization without login credentials. Intended for first-install bootstrap flows (for example creating the initial admin user when Dockhand auth is disabled). Can also be set with `DOCKHAND_ALLOW_UNAUTHENTICATED`.",
+				Optional:            true,
+			},
+			"request_retry_attempts": schema.Int64Attribute{
+				MarkdownDescription: "Maximum number of attempts for Dockhand login and API requests when transient connection failures occur. Defaults to `6`. Can also be set with `DOCKHAND_REQUEST_RETRY_ATTEMPTS`.",
+				Optional:            true,
+			},
+			"request_retry_min_seconds": schema.Int64Attribute{
+				MarkdownDescription: "Minimum wait between retry attempts in seconds. Defaults to `1`. Can also be set with `DOCKHAND_REQUEST_RETRY_MIN_SECONDS`.",
+				Optional:            true,
+			},
+			"request_retry_max_seconds": schema.Int64Attribute{
+				MarkdownDescription: "Maximum wait between retry attempts in seconds. Defaults to `5`. Can also be set with `DOCKHAND_REQUEST_RETRY_MAX_SECONDS`.",
 				Optional:            true,
 			},
 		},
@@ -150,6 +165,8 @@ func (p *dockhandProvider) Configure(ctx context.Context, req provider.Configure
 		allowUnauthenticated = config.AllowUnauthenticated.ValueBool()
 	}
 
+	retry := resolveRequestRetryConfig(config)
+
 	if endpoint == "" {
 		resp.Diagnostics.AddError(
 			"Missing Dockhand endpoint",
@@ -191,7 +208,7 @@ func (p *dockhandProvider) Configure(ctx context.Context, req provider.Configure
 			return
 		}
 		var err error
-		sessionCookie, err = Login(ctx, endpoint, username, password, mfaToken, authProvider, insecure)
+		sessionCookie, err = Login(ctx, endpoint, username, password, mfaToken, authProvider, insecure, retry)
 		if err != nil {
 			resp.Diagnostics.AddError("Authentication failed", err.Error())
 			return
@@ -206,6 +223,7 @@ func (p *dockhandProvider) Configure(ctx context.Context, req provider.Configure
 		)
 		return
 	}
+	client.SetRequestRetryPolicy(retry)
 
 	resp.ResourceData = client
 	resp.DataSourceData = client

--- a/internal/provider/request_retry.go
+++ b/internal/provider/request_retry.go
@@ -14,10 +14,10 @@ import (
 
 const (
 	defaultRequestRetryAttempts   = 6
-	defaultRequestRetryMinDelay     = 500 * time.Millisecond
-	defaultRequestRetryMaxDelay     = 5 * time.Second
-	defaultRequestRetryMinSeconds   = 1
-	defaultRequestRetryMaxSeconds   = 5
+	defaultRequestRetryMinDelay   = 500 * time.Millisecond
+	defaultRequestRetryMaxDelay   = 5 * time.Second
+	defaultRequestRetryMinSeconds = 1
+	defaultRequestRetryMaxSeconds = 5
 )
 
 type requestRetryConfig struct {

--- a/internal/provider/request_retry.go
+++ b/internal/provider/request_retry.go
@@ -1,0 +1,192 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultRequestRetryAttempts   = 6
+	defaultRequestRetryMinDelay     = 500 * time.Millisecond
+	defaultRequestRetryMaxDelay     = 5 * time.Second
+	defaultRequestRetryMinSeconds   = 1
+	defaultRequestRetryMaxSeconds   = 5
+)
+
+type requestRetryConfig struct {
+	attempts int
+	minDelay time.Duration
+	maxDelay time.Duration
+}
+
+func defaultRequestRetryConfig() requestRetryConfig {
+	return requestRetryConfig{
+		attempts: defaultRequestRetryAttempts,
+		minDelay: defaultRequestRetryMinDelay,
+		maxDelay: defaultRequestRetryMaxDelay,
+	}
+}
+
+func resolveRequestRetryConfig(config dockhandProviderModel) requestRetryConfig {
+	retry := defaultRequestRetryConfig()
+
+	if raw := strings.TrimSpace(os.Getenv("DOCKHAND_REQUEST_RETRY_ATTEMPTS")); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
+			retry.attempts = v
+		}
+	}
+	if !config.RequestRetryAttempts.IsNull() && !config.RequestRetryAttempts.IsUnknown() {
+		if v := config.RequestRetryAttempts.ValueInt64(); v > 0 {
+			retry.attempts = int(v)
+		}
+	}
+
+	minSeconds := defaultRequestRetryMinSeconds
+	if raw := strings.TrimSpace(os.Getenv("DOCKHAND_REQUEST_RETRY_MIN_SECONDS")); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v >= 0 {
+			minSeconds = v
+		}
+	}
+	if !config.RequestRetryMinSeconds.IsNull() && !config.RequestRetryMinSeconds.IsUnknown() {
+		minSeconds = int(config.RequestRetryMinSeconds.ValueInt64())
+	}
+
+	maxSeconds := defaultRequestRetryMaxSeconds
+	if raw := strings.TrimSpace(os.Getenv("DOCKHAND_REQUEST_RETRY_MAX_SECONDS")); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
+			maxSeconds = v
+		}
+	}
+	if !config.RequestRetryMaxSeconds.IsNull() && !config.RequestRetryMaxSeconds.IsUnknown() {
+		maxSeconds = int(config.RequestRetryMaxSeconds.ValueInt64())
+	}
+
+	if minSeconds < 0 {
+		minSeconds = 0
+	}
+	if maxSeconds < 1 {
+		maxSeconds = defaultRequestRetryMaxSeconds
+	}
+	if minSeconds > maxSeconds {
+		minSeconds = maxSeconds
+	}
+
+	retry.minDelay = time.Duration(minSeconds) * time.Second
+	retry.maxDelay = time.Duration(maxSeconds) * time.Second
+	return retry
+}
+
+func (c *requestRetryConfig) attemptsOrDefault() int {
+	if c == nil || c.attempts < 1 {
+		return defaultRequestRetryAttempts
+	}
+	return c.attempts
+}
+
+func (c *requestRetryConfig) sleep(ctx context.Context, attempt int) error {
+	minDelay := defaultRequestRetryMinDelay
+	maxDelay := defaultRequestRetryMaxDelay
+	if c != nil {
+		if c.minDelay > 0 {
+			minDelay = c.minDelay
+		}
+		if c.maxDelay > 0 {
+			maxDelay = c.maxDelay
+		}
+	}
+
+	delay := minDelay
+	for i := 0; i < attempt; i++ {
+		delay *= 2
+		if delay > maxDelay {
+			delay = maxDelay
+			break
+		}
+	}
+
+	t := time.NewTimer(delay)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+func isTransientNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "connection refused"),
+		strings.Contains(msg, "connection reset"),
+		strings.Contains(msg, "broken pipe"),
+		strings.Contains(msg, "no route to host"),
+		strings.Contains(msg, "eof"),
+		strings.Contains(msg, "timeout"),
+		strings.Contains(msg, "temporarily unavailable"):
+		return true
+	}
+
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+
+	return false
+}
+
+func shouldRetryHTTPStatus(method string, status int) bool {
+	switch method {
+	case http.MethodGet, http.MethodDelete:
+	default:
+		return false
+	}
+	switch status {
+	case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldRetryRequest(method string, status int, err error) bool {
+	if isTransientNetworkError(err) {
+		return true
+	}
+	if err == nil {
+		return shouldRetryHTTPStatus(method, status)
+	}
+	return extractHTTPStatusFromError(err) > 0 && shouldRetryHTTPStatus(method, extractHTTPStatusFromError(err))
+}
+
+func extractHTTPStatusFromError(err error) int {
+	if err == nil {
+		return 0
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "status ") {
+		return 0
+	}
+	var status int
+	if _, scanErr := fmt.Sscanf(msg, "dockhand api returned status %d", &status); scanErr == nil {
+		return status
+	}
+	if _, scanErr := fmt.Sscanf(msg, "dockhand login failed (status %d)", &status); scanErr == nil {
+		return status
+	}
+	return 0
+}

--- a/internal/provider/request_retry_test.go
+++ b/internal/provider/request_retry_test.go
@@ -1,0 +1,53 @@
+package provider
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestResolveRequestRetryConfigDefaults(t *testing.T) {
+	retry := resolveRequestRetryConfig(dockhandProviderModel{})
+	if retry.attempts != defaultRequestRetryAttempts {
+		t.Fatalf("attempts = %d, want %d", retry.attempts, defaultRequestRetryAttempts)
+	}
+	if retry.minDelay != time.Duration(defaultRequestRetryMinSeconds)*time.Second {
+		t.Fatalf("minDelay = %s, want %s", retry.minDelay, time.Duration(defaultRequestRetryMinSeconds)*time.Second)
+	}
+	if retry.maxDelay != time.Duration(defaultRequestRetryMaxSeconds)*time.Second {
+		t.Fatalf("maxDelay = %s, want %s", retry.maxDelay, time.Duration(defaultRequestRetryMaxSeconds)*time.Second)
+	}
+}
+
+func TestResolveRequestRetryConfigFromProvider(t *testing.T) {
+	cfg := dockhandProviderModel{
+		RequestRetryAttempts:   types.Int64Value(8),
+		RequestRetryMinSeconds: types.Int64Value(2),
+		RequestRetryMaxSeconds: types.Int64Value(10),
+	}
+	retry := resolveRequestRetryConfig(cfg)
+	if retry.attempts != 8 {
+		t.Fatalf("attempts = %d, want 8", retry.attempts)
+	}
+	if retry.minDelay != 2*time.Second {
+		t.Fatalf("minDelay = %s, want 2s", retry.minDelay)
+	}
+	if retry.maxDelay != 10*time.Second {
+		t.Fatalf("maxDelay = %s, want 10s", retry.maxDelay)
+	}
+}
+
+func TestShouldRetryRequestOnConnectionRefused(t *testing.T) {
+	if !shouldRetryRequest(http.MethodPost, 0, fmt.Errorf("dial tcp: connect: connection refused")) {
+		t.Fatal("expected POST connection refused to retry")
+	}
+}
+
+func TestShouldNotRetryRequestOnClientError(t *testing.T) {
+	if shouldRetryRequest(http.MethodPost, http.StatusBadRequest, nil) {
+		t.Fatal("expected 400 POST not to retry")
+	}
+}

--- a/internal/provider/resource_git_credential.go
+++ b/internal/provider/resource_git_credential.go
@@ -60,7 +60,7 @@ func (r *gitCredentialResource) Schema(_ context.Context, _ resource.SchemaReque
 				Required:            true,
 			},
 			"auth_type": schema.StringAttribute{
-				MarkdownDescription: "Authentication type. Known values observed: `password`.",
+				MarkdownDescription: "Authentication type. Supported values: `password`, `ssh`.",
 				Required:            true,
 			},
 			"username": schema.StringAttribute{

--- a/internal/provider/resource_git_credential_test.go
+++ b/internal/provider/resource_git_credential_test.go
@@ -1,0 +1,42 @@
+package provider
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestGitCredentialPayloadUsesSSHPrivateKeyField(t *testing.T) {
+	key := "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----"
+	payload := gitCredentialPayload{
+		Name:     "sample_key",
+		AuthType: "ssh",
+		SSHKey:   &key,
+	}
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	body := string(raw)
+	if !strings.Contains(body, `"sshPrivateKey"`) {
+		t.Fatalf("expected sshPrivateKey JSON field, got %s", body)
+	}
+	if strings.Contains(body, `"sshKey"`) {
+		t.Fatalf("did not expect legacy sshKey JSON field, got %s", body)
+	}
+}
+
+func TestBuildGitCredentialPayloadRequiresSSHKey(t *testing.T) {
+	plan := gitCredentialModel{
+		Name:     types.StringValue("sample_key"),
+		AuthType: types.StringValue("ssh"),
+	}
+
+	_, err := buildGitCredentialPayload(plan, gitCredentialModel{}, true)
+	if err == nil {
+		t.Fatal("expected error when ssh_key missing on create")
+	}
+}

--- a/internal/provider/resource_git_credential_test.go
+++ b/internal/provider/resource_git_credential_test.go
@@ -1,31 +1,19 @@
 package provider
 
 import (
-	"encoding/json"
-	"strings"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestGitCredentialPayloadUsesSSHPrivateKeyField(t *testing.T) {
-	key := "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----"
-	payload := gitCredentialPayload{
-		Name:     "sample_key",
-		AuthType: "ssh",
-		SSHKey:   &key,
+	field, ok := reflect.TypeOf(gitCredentialPayload{}).FieldByName("SSHKey")
+	if !ok {
+		t.Fatal("expected SSHKey field on gitCredentialPayload")
 	}
-
-	raw, err := json.Marshal(payload)
-	if err != nil {
-		t.Fatalf("marshal payload: %v", err)
-	}
-	body := string(raw)
-	if !strings.Contains(body, `"sshPrivateKey"`) {
-		t.Fatalf("expected sshPrivateKey JSON field, got %s", body)
-	}
-	if strings.Contains(body, `"sshKey"`) {
-		t.Fatalf("did not expect legacy sshKey JSON field, got %s", body)
+	if got := field.Tag.Get("json"); got != "sshPrivateKey,omitempty" {
+		t.Fatalf("SSHKey json tag = %q, want sshPrivateKey,omitempty", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **#117:** Retry transient connection failures for all Dockhand API methods during apply (including `POST /api/users` bootstrap calls when `allow_unauthenticated = true`). Adds optional provider `request_retry_*` settings.
- **#119:** Send git credential SSH keys as Dockhand `sshPrivateKey` instead of the incorrect `sshKey` JSON field.

Fixes #117
Fixes #119

## Test plan
- [x] `go test ./internal/provider`
- [x] `./scripts/verify.sh --quality`
- [ ] Release `v0.1.82` after merge (single patch release for both fixes)


Made with [Cursor](https://cursor.com)