### PR TITLE
feat: add context_dir to dockhand_git_stack

### DIFF
--- a/docs/api-matrix.md
+++ b/docs/api-matrix.md
@@ -68,7 +68,7 @@ Live verification artifacts:
 | `dockhand_git_repository` | Update | `PUT /api/git/repositories/{id}` | Updates repo integration settings. | partial |
 | `dockhand_git_repository` | Delete | `DELETE /api/git/repositories/{id}` | `404` treated as already deleted. | implemented |
 | `dockhand_git_repository_test_action` | Test connectivity | `POST /api/git/repositories/test` | One-shot repository connectivity test. Supports inline URL payloads or existing `repository_id` resolution. | implemented |
-| `dockhand_git_stack` | Create/Read/Update/Delete | `GET/POST/PUT/DELETE /api/git/stacks?env={env_id}` | Manages deployed Git-backed stacks (stack name + repo + compose path) in a target environment. | implemented |
+| `dockhand_git_stack` | Create/Read/Update/Delete | `GET/POST/PUT/DELETE /api/git/stacks?env={env_id}` | Manages deployed Git-backed stacks (stack name + repo + compose path + optional context directory) in a target environment. Supports `context_dir` (`contextDir`) for shared env files and volume paths outside the compose folder. | implemented |
 | `dockhand_git_stack_webhook_action` | Trigger webhook | `POST /api/git/stacks/{id}/webhook` | One-shot trigger for git stack deploy/sync webhook flow. | implemented |
 | `dockhand_git_stack_deploy_action` | Trigger deploy | `POST /api/git/stacks/{id}/deploy-stream` | One-shot deploy request for git-managed stacks. | implemented |
 | `dockhand_git_stack_env_file` | Read available env-file paths | `GET /api/git/stacks/{id}/env-files` | Reads env-file path inventory for a git-managed stack. | implemented |

--- a/docs/resources/git_stack.md
+++ b/docs/resources/git_stack.md
@@ -19,6 +19,21 @@ resource "dockhand_git_stack" "ollama" {
 }
 ```
 
+Shared env files outside the compose directory:
+
+```terraform
+resource "dockhand_git_stack" "metube" {
+  env             = "11"
+  stack_name      = "metube"
+  repository_id   = "1"
+  compose_path    = "stacks/metube/compose.yml"
+  context_dir     = "."
+  env_file_path   = "./shared.env"
+}
+```
+
+Set `context_dir` to widen Dockhand's compose working directory (relative to the repo root). This matches the Dockhand UI "Context directory" setting and is required when `env_file_path` or compose volume paths reference files outside the compose file folder. The compose file path must remain inside the context directory.
+
 ## Schema
 
 ### Required
@@ -34,6 +49,7 @@ resource "dockhand_git_stack" "ollama" {
 - `url` (String)
 - `branch` (String, default: `main`)
 - `credential_id` (String)
+- `context_dir` (String) Repository-relative working directory for Docker Compose. Use `.` for the repo root when shared files live outside the compose file directory.
 - `env_file_path` (String)
 - `auto_update_enabled` (Boolean, default: `false`)
 - `auto_update_cron` (String, default: `0 3 * * *`)

--- a/examples/resources/dockhand_git_stack/resource.tf
+++ b/examples/resources/dockhand_git_stack/resource.tf
@@ -3,6 +3,8 @@ resource "dockhand_git_stack" "example" {
   stack_name      = "example-git-stack"
   repository_id   = "1"
   compose_path    = "stacks/example/stack.yaml"
+  context_dir     = "."
+  env_file_path   = "./shared.env"
   deploy_now      = true
   build_on_deploy = true
   repull_images   = false

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -388,6 +388,7 @@ type gitStackPayload struct {
 	Branch            *string                 `json:"branch,omitempty"`
 	CredentialID      *int64                  `json:"credentialId,omitempty"`
 	ComposePath       string                  `json:"composePath"`
+	ContextDir        *string                 `json:"contextDir,omitempty"`
 	EnvFilePath       *string                 `json:"envFilePath,omitempty"`
 	AutoUpdateEnabled bool                    `json:"autoUpdateEnabled"`
 	AutoUpdate        *bool                   `json:"autoUpdate,omitempty"`
@@ -415,6 +416,7 @@ type gitStackResponse struct {
 	EnvironmentID      *int64                      `json:"environmentId"`
 	RepositoryID       *int64                      `json:"repositoryId"`
 	ComposePath        *string                     `json:"composePath"`
+	ContextDir         *string                     `json:"contextDir"`
 	EnvFilePath        *string                     `json:"envFilePath"`
 	AutoUpdate         bool                        `json:"autoUpdate"`
 	AutoUpdateEnabled  *bool                       `json:"autoUpdateEnabled"`

--- a/internal/provider/resource_git_stack.go
+++ b/internal/provider/resource_git_stack.go
@@ -48,6 +48,7 @@ type gitStackModel struct {
 	Branch                    types.String `tfsdk:"branch"`
 	CredentialID              types.String `tfsdk:"credential_id"`
 	ComposePath               types.String `tfsdk:"compose_path"`
+	ContextDir                types.String `tfsdk:"context_dir"`
 	EnvFilePath               types.String `tfsdk:"env_file_path"`
 	AutoUpdateEnabled         types.Bool   `tfsdk:"auto_update_enabled"`
 	AutoUpdateCron            types.String `tfsdk:"auto_update_cron"`
@@ -128,6 +129,11 @@ func (r *gitStackResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 			"compose_path": schema.StringAttribute{
 				Required: true,
+			},
+			"context_dir": schema.StringAttribute{
+				MarkdownDescription: "Repository-relative working directory for Docker Compose (Dockhand context directory). Use this to reference files outside the compose file folder, such as shared env files at the repo root.",
+				Optional:            true,
+				Computed:            true,
 			},
 			"env_file_path": schema.StringAttribute{
 				Optional: true,
@@ -432,6 +438,13 @@ func buildGitStackPayload(plan gitStackModel) (gitStackPayload, error) {
 	// Support Dockhand API variants that use either autoUpdateEnabled or autoUpdate.
 	payload.AutoUpdate = &autoUpdateEnabled
 
+	if !plan.ContextDir.IsNull() && !plan.ContextDir.IsUnknown() {
+		v := strings.TrimSpace(plan.ContextDir.ValueString())
+		if v != "" {
+			payload.ContextDir = &v
+		}
+	}
+
 	if !plan.EnvFilePath.IsNull() && !plan.EnvFilePath.IsUnknown() {
 		v := strings.TrimSpace(plan.EnvFilePath.ValueString())
 		if v != "" {
@@ -553,6 +566,11 @@ func modelFromGitStackResponse(in *gitStackResponse) gitStackModel {
 	} else {
 		out.ComposePath = types.StringNull()
 	}
+	if in.ContextDir != nil {
+		out.ContextDir = types.StringValue(*in.ContextDir)
+	} else {
+		out.ContextDir = types.StringNull()
+	}
 	if in.EnvFilePath != nil {
 		out.EnvFilePath = types.StringValue(*in.EnvFilePath)
 	} else {
@@ -652,6 +670,9 @@ func mergeGitStackState(preferred gitStackModel, remote gitStackModel) gitStackM
 	}
 	if (out.ComposePath.IsNull() || out.ComposePath.IsUnknown()) && !preferred.ComposePath.IsNull() && !preferred.ComposePath.IsUnknown() {
 		out.ComposePath = preferred.ComposePath
+	}
+	if (out.ContextDir.IsNull() || out.ContextDir.IsUnknown()) && !preferred.ContextDir.IsNull() && !preferred.ContextDir.IsUnknown() {
+		out.ContextDir = preferred.ContextDir
 	}
 	if (out.EnvFilePath.IsNull() || out.EnvFilePath.IsUnknown()) && !preferred.EnvFilePath.IsNull() && !preferred.EnvFilePath.IsUnknown() {
 		out.EnvFilePath = preferred.EnvFilePath

--- a/internal/provider/resource_git_stack_test.go
+++ b/internal/provider/resource_git_stack_test.go
@@ -37,6 +37,76 @@ func (f *fakeGitStackDestroyClient) DeleteGitStack(_ context.Context, env string
 	return f.deleteGitStackStatus, f.deleteGitStackErr
 }
 
+func TestBuildGitStackPayloadIncludesContextDir(t *testing.T) {
+	plan := gitStackModel{
+		StackName:                 types.StringValue("test-stack"),
+		ComposePath:               types.StringValue("stacks/metube/compose.yml"),
+		ContextDir:                types.StringValue("."),
+		EnvFilePath:               types.StringValue("./shared.env"),
+		WebhookEnabled:            types.BoolValue(false),
+		WebhookSecretAutoGenerate: types.BoolValue(false),
+		WebhookSecret:             types.StringNull(),
+		AutoUpdateEnabled:         types.BoolValue(false),
+		AutoUpdateCron:            types.StringValue("0 3 * * *"),
+		DeployNow:                 types.BoolValue(false),
+		EnvVarsJSON:               types.StringValue("[]"),
+		URL:                       types.StringValue("https://example.com/repo.git"),
+		Branch:                    types.StringValue("main"),
+	}
+
+	payload, err := buildGitStackPayload(plan)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if payload.ContextDir == nil || *payload.ContextDir != "." {
+		t.Fatalf("expected contextDir . in payload, got %#v", payload.ContextDir)
+	}
+	if payload.EnvFilePath == nil || *payload.EnvFilePath != "./shared.env" {
+		t.Fatalf("expected envFilePath ./shared.env in payload, got %#v", payload.EnvFilePath)
+	}
+}
+
+func TestGitStackPayloadContextDirJSONTag(t *testing.T) {
+	field, ok := reflect.TypeOf(gitStackPayload{}).FieldByName("ContextDir")
+	if !ok {
+		t.Fatal("expected ContextDir field on gitStackPayload")
+	}
+	if tag := field.Tag.Get("json"); tag != "contextDir,omitempty" {
+		t.Fatalf("expected json tag contextDir,omitempty, got %q", tag)
+	}
+}
+
+func TestModelFromGitStackResponseMapsContextDir(t *testing.T) {
+	contextDir := "."
+	composePath := "stacks/metube/compose.yml"
+	resp := &gitStackResponse{
+		ID:          1,
+		StackName:   "test-stack",
+		AutoUpdate:  false,
+		ContextDir:  &contextDir,
+		ComposePath: &composePath,
+	}
+
+	model := modelFromGitStackResponse(resp)
+	if model.ContextDir.IsNull() || model.ContextDir.ValueString() != "." {
+		t.Fatalf("expected context_dir . from response, got null=%v value=%q", model.ContextDir.IsNull(), model.ContextDir.ValueString())
+	}
+}
+
+func TestMergeGitStackStatePreservesContextDirWhenRemoteOmitsIt(t *testing.T) {
+	preferred := gitStackModel{
+		ContextDir: types.StringValue("."),
+	}
+	remote := gitStackModel{
+		ContextDir: types.StringNull(),
+	}
+
+	merged := mergeGitStackState(preferred, remote)
+	if merged.ContextDir.IsNull() || merged.ContextDir.ValueString() != "." {
+		t.Fatalf("expected context_dir to preserve configured value, got null=%v value=%q", merged.ContextDir.IsNull(), merged.ContextDir.ValueString())
+	}
+}
+
 func TestBuildGitStackPayloadWebhookDisabledAutoGenerateSendsEmptySecret(t *testing.T) {
 	plan := gitStackModel{
 		StackName:                 types.StringValue("test-stack"),


### PR DESCRIPTION
## Summary
- Add optional `context_dir` attribute to `dockhand_git_stack`, mapped to Dockhand API `contextDir`
- Enables shared env files and volume paths outside the compose file directory (fixes #121)
- Update docs, example, api-matrix, and unit tests

## Test plan
- [x] `./scripts/verify.sh --quality`
- [x] Unit tests for payload mapping, JSON tag, response mapping, and merge behavior

Fixes #121

Made with [Cursor](https://cursor.com)