### PR TITLE
feat: release when main has unreleased commits

### DIFF
--- a/.github/workflows/agent-release-orchestrate.yml
+++ b/.github/workflows/agent-release-orchestrate.yml
@@ -65,11 +65,15 @@ jobs:
           jq -r '.version' /tmp/release-gate.json > /tmp/version
           jq -r '.tier' /tmp/release-gate.json > /tmp/tier
           jq -r '.awaiting_release_issues | join(", ")' /tmp/release-gate.json > /tmp/awaiting
+          jq -r '.unreleased_commits_on_main' /tmp/release-gate.json > /tmp/unreleased
+          jq -r '.release_trigger // empty' /tmp/release-gate.json > /tmp/trigger
           {
             echo "ready=$(cat /tmp/ready)"
             echo "version=$(cat /tmp/version)"
             echo "tier=$(cat /tmp/tier)"
             echo "awaiting=$(cat /tmp/awaiting)"
+            echo "unreleased=$(cat /tmp/unreleased)"
+            echo "trigger=$(cat /tmp/trigger)"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Create release lens issue
@@ -79,6 +83,8 @@ jobs:
           VERSION: ${{ steps.gate.outputs.version }}
           TIER: ${{ steps.gate.outputs.tier }}
           AWAITING: ${{ steps.gate.outputs.awaiting }}
+          UNRELEASED: ${{ steps.gate.outputs.unreleased }}
+          TRIGGER: ${{ steps.gate.outputs.trigger }}
         with:
           script: |
             const owner = context.repo.owner;
@@ -86,6 +92,8 @@ jobs:
             const version = process.env.VERSION;
             const tier = process.env.TIER || "patch";
             const awaiting = process.env.AWAITING || "";
+            const unreleased = process.env.UNRELEASED || "0";
+            const trigger = process.env.TRIGGER || "unknown";
             const title = `release: prepare v${version}`;
 
             const existing = await github.rest.search.issuesAndPullRequests({
@@ -112,7 +120,7 @@ jobs:
               "## Problem",
               `Provider release **v${version}** is ready for automated release-tier lens review and tagging.`,
               "",
-              "CI release gates passed. Fixes are on `main` and issues are awaiting release.",
+              "CI release gates passed. Release work is queued on `main`.",
               "",
               "## Done when",
               `- Complete release-tier lens review per \`docs/testing/release-lens-review.md\` (**${tier}** tier)`,
@@ -122,7 +130,9 @@ jobs:
               "",
               "## Context",
               `- Tier: ${tier}`,
-              `- Awaiting-release issues: ${awaiting || "none listed"}`,
+              `- Release trigger: ${trigger}`,
+              `- Unreleased commits on main since latest tag: ${unreleased}`,
+              `- Awaiting-release issues: ${awaiting || "none"}`,
               `- Gate script: \`scripts/release_gate_check.py\``,
               `- Tagging workflow: \`.github/workflows/agent-release-tag.yml\``,
             ].join("\n");

--- a/docs/AGENT_AUTONOMY.md
+++ b/docs/AGENT_AUTONOMY.md
@@ -66,7 +66,7 @@ No manual merge or workflow approval is required for routine report refresh.
 
 1. Fixes merge to `main`; **Agent Merge Cleanup** (agent PRs) or **Issue Resolution Notify** (human PRs) labels linked issues `awaiting-release`.
 2. **Release Drafter** maintains the next draft version on each `main` push.
-3. **Agent Release Orchestrate** opens `release: prepare vX.Y.Z` when `scripts/release_gate_check.py --mode lens` passes (after a successful **validated** **Dockhand Release Watch** on `main`, or via manual dispatch).
+3. **Agent Release Orchestrate** opens `release: prepare vX.Y.Z` when `scripts/release_gate_check.py --mode lens` passes (validated **Dockhand Release Watch** on `main`, or manual dispatch). Release work includes `awaiting-release` issues **or** any commits on `main` since the latest published tag.
 4. **Issue Agent Intake** dispatches a Cloud Agent with the release-tier lens set.
 5. Agent appends lens sweeps + `### Release vX.Y.Z — verdict` with **Clear to tag: yes** to `docs/reports/agent-review-log.md` and merges via the normal agent PR loop.
 6. **Agent Release Tag** runs the full release pipeline when `scripts/release_gate_check.py --mode tag` passes: ensure Release Watch validated, **Release Artifacts** (GPG-signed checksums + attestations), label `awaiting-release` issues, cut `CHANGELOG.md`, and post release comments on linked issues.

--- a/docs/testing/release-gate.md
+++ b/docs/testing/release-gate.md
@@ -12,7 +12,7 @@ Provider releases should only be cut when all of the following pass on `main`:
 
 ## Release lens review (automated)
 
-**Agent Release Orchestrate** opens a `release: prepare vX.Y.Z` issue when CI gates pass and fixes are `awaiting-release`. It runs after a successful **Dockhand Release Watch** on `main` or via manual dispatch (no standalone cron). **Issue Agent Intake** dispatches a Cloud Agent with the release-tier lens set per `docs/testing/release-lens-review.md`. **Agent Release Tag** is the single release completion workflow: ensure Release Watch validated → **Release Artifacts** (GPG-signed checksums for Terraform Registry + GitHub artifact attestations) → label `awaiting-release` issues, cut `CHANGELOG.md`, and post release comments on linked issues.
+**Agent Release Orchestrate** opens a `release: prepare vX.Y.Z` issue when CI gates pass and there is release work on `main`: open `awaiting-release` issues **or** commits since the latest published tag (including Dependabot dependency bumps). It runs after a successful **Dockhand Release Watch** on `main` or via manual dispatch (no standalone cron). **Issue Agent Intake** dispatches a Cloud Agent with the release-tier lens set per `docs/testing/release-lens-review.md`. **Agent Release Tag** is the single release completion workflow: ensure Release Watch validated → **Release Artifacts** (GPG-signed checksums for Terraform Registry + GitHub artifact attestations) → label `awaiting-release` issues, cut `CHANGELOG.md`, and post release comments on linked issues.
 
 Do not tag while **high** severity findings are open in the release verdict.
 
@@ -28,8 +28,8 @@ Before **Agent Release Tag** publishes `vX.Y.Z`:
 1. No open `compatibility` issues for the current Dockhand release.
 2. Required workflows green on `main` (Go CI, Govulncheck, Workflow Lint, Gitleaks, Dependency Review, Acceptance Full, Dockhand Release Watch).
 3. Release Drafter draft exists for `vX.Y.Z` and the tag is not published yet.
-4. At least one `awaiting-release` issue exists (for lens dispatch) **or** the review log already contains **Clear to tag: yes** for `vX.Y.Z`.
-5. `docs/reports/agent-review-log.md` on `main` contains `### Release vX.Y.Z — verdict` with **Clear to tag: yes**.
+4. At least one `awaiting-release` issue **or** commits on `main` since the latest published tag (dependency bumps, automation fixes, etc.).
+5. `docs/reports/agent-review-log.md` on `main` contains `### Release vX.Y.Z — verdict` with **Clear to tag: yes** (required for tagging; not for opening the release lens issue).
 
 Tagging and artifact publish are performed by `.github/workflows/agent-release-tag.yml`:
 

--- a/scripts/release_gate_check.py
+++ b/scripts/release_gate_check.py
@@ -39,8 +39,21 @@ class GateResult:
     tier: str = "patch"
     blockers: list[str] = field(default_factory=list)
     awaiting_release_issues: list[int] = field(default_factory=list)
+    unreleased_commits_on_main: int = 0
     lens_verdict_clear: bool = False
     open_release_issue: int | None = None
+
+    @property
+    def has_release_work(self) -> bool:
+        return bool(self.awaiting_release_issues) or self.unreleased_commits_on_main > 0
+
+    @property
+    def release_trigger(self) -> str | None:
+        if self.awaiting_release_issues:
+            return "awaiting_release_issues"
+        if self.unreleased_commits_on_main > 0:
+            return "unreleased_main_commits"
+        return None
 
     @property
     def ready_for_lens_dispatch(self) -> bool:
@@ -48,8 +61,8 @@ class GateResult:
             self.ci_gates_pass
             and not self.lens_verdict_clear
             and self.open_release_issue is None
-            and bool(self.awaiting_release_issues)
             and bool(self.version)
+            and self.has_release_work
         )
 
     @property
@@ -66,6 +79,9 @@ class GateResult:
             "tier": self.tier,
             "blockers": self.blockers,
             "awaiting_release_issues": self.awaiting_release_issues,
+            "unreleased_commits_on_main": self.unreleased_commits_on_main,
+            "has_release_work": self.has_release_work,
+            "release_trigger": self.release_trigger,
             "lens_verdict_clear": self.lens_verdict_clear,
             "open_release_issue": self.open_release_issue,
         }
@@ -165,7 +181,7 @@ def awaiting_release_issues() -> list[int]:
             "issue",
             "list",
             "--state",
-            "all",
+            "open",
             "--label",
             "awaiting-release",
             "--json",
@@ -183,6 +199,24 @@ def awaiting_release_issues() -> list[int]:
             continue
         numbers.append(int(item["number"]))
     return numbers
+
+
+def commits_ahead_of_latest_release() -> int:
+    latest = latest_release_tag()
+    if latest is None:
+        proc = subprocess.run(
+            ["gh", "api", f"repos/{_repo()}/commits/main", "--jq", ".sha"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return 1 if proc.returncode == 0 and proc.stdout.strip() else 0
+
+    data = _gh_json(["api", f"repos/{_repo()}/compare/{latest.tag()}...main"])
+    if not isinstance(data, dict):
+        return 0
+    return max(int(data.get("ahead_by", 0)), 0)
 
 
 def workflow_runs(name: str, *, limit: int = 15) -> list[dict]:
@@ -350,6 +384,7 @@ def evaluate_gate(*, release_watch_mode: str = "strict") -> GateResult:
     result.tag = draft.tag()
     result.tier = release_tier(previous, draft)
     result.awaiting_release_issues = awaiting_release_issues()
+    result.unreleased_commits_on_main = commits_ahead_of_latest_release()
     result.open_release_issue = find_open_release_issue(result.version)
 
     review_log = ROOT / "docs/reports/agent-review-log.md"

--- a/scripts/test_release_gate_check.py
+++ b/scripts/test_release_gate_check.py
@@ -57,6 +57,32 @@ class WorkflowGreenTest(unittest.TestCase):
             )
 
 
+class GateResultTest(unittest.TestCase):
+    def test_ready_for_lens_with_unreleased_commits(self) -> None:
+        result = gate.GateResult(
+            ci_gates_pass=True,
+            version="0.1.87",
+            tag="v0.1.87",
+            unreleased_commits_on_main=3,
+        )
+        self.assertTrue(result.ready_for_lens_dispatch)
+        self.assertEqual(result.release_trigger, "unreleased_main_commits")
+
+    def test_ready_for_lens_without_release_work(self) -> None:
+        result = gate.GateResult(ci_gates_pass=True, version="0.1.87", tag="v0.1.87")
+        self.assertFalse(result.ready_for_lens_dispatch)
+
+    def test_awaiting_release_takes_precedence(self) -> None:
+        result = gate.GateResult(
+            ci_gates_pass=True,
+            version="0.1.87",
+            tag="v0.1.87",
+            awaiting_release_issues=[42],
+            unreleased_commits_on_main=5,
+        )
+        self.assertEqual(result.release_trigger, "awaiting_release_issues")
+
+
 class CutChangelogTest(unittest.TestCase):
     def test_cut_changelog_inserts_version_section(self) -> None:
         from release_housekeeping import cut_changelog


### PR DESCRIPTION
## Summary
- Release lens dispatch now triggers when `main` has commits since the latest published tag (e.g. Dependabot bumps), not only when `awaiting-release` issues exist.
- Fixes `awaiting-release` lookup to open issues only.

## Why
Dependency bumps were merging to `main` but v0.1.87 never entered the release pipeline because no linked issues carried `awaiting-release`.

## Test plan
- [ ] `./scripts/test-agent-helpers.sh` / unit tests pass
- [ ] After merge, `scripts/release_gate_check.py --mode lens` reports `ready_for_lens_dispatch: true`
- [ ] Agent Release Orchestrate opens `release: prepare v0.1.87`


Made with [Cursor](https://cursor.com)