### PR TITLE
feat: prune stale agent and automation branches

### DIFF
--- a/.github/workflows/agent-merge-cleanup.yml
+++ b/.github/workflows/agent-merge-cleanup.yml
@@ -66,8 +66,27 @@ jobs:
             }
 
             const headRef = pr.head?.ref || "";
-            if (!headRef.startsWith("agent/") && context.eventName !== "workflow_dispatch") {
-              core.info(`Skipping non-agent PR #${pr.number} (${headRef || "unknown ref"}).`);
+            const keepBranches = new Set(["automation/compat-reports-sync"]);
+            const isAgentBranch = headRef.startsWith("agent/");
+            const isAutomationBranch = headRef.startsWith("automation/");
+
+            if (!isAgentBranch && !isAutomationBranch && context.eventName !== "workflow_dispatch") {
+              core.info(`Skipping non-automated PR #${pr.number} (${headRef || "unknown ref"}).`);
+              return;
+            }
+
+            if (!isAgentBranch) {
+              if (headRef && !keepBranches.has(headRef)) {
+                try {
+                  await github.rest.git.deleteRef({ owner, repo, ref: `heads/${headRef}` });
+                  core.info(`Deleted automation branch ${headRef} after merge.`);
+                } catch (error) {
+                  if (error.status !== 422) {
+                    core.warning(`Could not delete branch ${headRef}: ${error.message}`);
+                  }
+                }
+              }
+              core.info(`Skipping issue cleanup for automation PR #${pr.number}.`);
               return;
             }
 

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   hygiene:
-    name: Prune stale agent branches and trackers
+    name: Prune stale agent/automation branches and trackers
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/scripts/repo_hygiene.py
+++ b/scripts/repo_hygiene.py
@@ -28,7 +28,43 @@ DELETE_CLOSED_TITLE_RES = (
     re.compile(r"^release: prepare v", re.I),
 )
 
-KEEP_BRANCH_NAMES = frozenset()
+KEEP_BRANCH_NAMES = frozenset(
+    {
+        # Reused by compat-reports-sync.yml for force-pushed docs-only PRs.
+        "automation/compat-reports-sync",
+    }
+)
+
+BRANCH_PREFIXES = ("agent/", "automation/")
+
+
+def is_prunable_branch(branch: str) -> bool:
+    return any(branch.startswith(prefix) for prefix in BRANCH_PREFIXES)
+
+
+def list_branches_with_prefix(prefix: str) -> list[str]:
+    data = _gh_json(["api", f"repos/{_repo()}/git/matching-refs/heads/{prefix}"])
+    if not isinstance(data, list):
+        return []
+    out: list[str] = []
+    for item in data:
+        ref = str(item.get("ref", ""))
+        if ref.startswith("refs/heads/"):
+            out.append(ref.removeprefix("refs/heads/"))
+    return sorted(out)
+
+
+def list_agent_branches() -> list[str]:
+    return list_branches_with_prefix("agent/")
+
+
+def list_automation_branches() -> list[str]:
+    return list_branches_with_prefix("automation/")
+
+
+def stale_branches_to_prune() -> list[str]:
+    branches = set(list_agent_branches()) | set(list_automation_branches())
+    return sorted(branches)
 
 
 def _repo() -> str:
@@ -59,18 +95,6 @@ def _gh_json(args: list[str]) -> object:
     return json.loads(proc.stdout)
 
 
-def list_agent_branches() -> list[str]:
-    data = _gh_json(["api", f"repos/{_repo()}/git/matching-refs/heads/agent/"])
-    if not isinstance(data, list):
-        return []
-    out: list[str] = []
-    for item in data:
-        ref = str(item.get("ref", ""))
-        if ref.startswith("refs/heads/"):
-            out.append(ref.removeprefix("refs/heads/"))
-    return sorted(out)
-
-
 def branch_has_open_pr(branch: str) -> bool:
     data = _gh_json(["pr", "list", "--state", "open", "--head", branch, "--json", "number"])
     return isinstance(data, list) and len(data) > 0
@@ -87,6 +111,8 @@ def _gh_run(args: list[str]) -> None:
 
 def delete_branch(branch: str, *, apply: bool) -> bool:
     if branch in KEEP_BRANCH_NAMES:
+        return False
+    if not is_prunable_branch(branch):
         return False
     if branch_has_open_pr(branch):
         return False
@@ -278,7 +304,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--branches",
         action="store_true",
-        help="Delete stale agent/* branches without open PRs",
+        help="Delete stale agent/* and automation/* branches without open PRs",
     )
     parser.add_argument(
         "--delete-closed-issues",
@@ -317,7 +343,7 @@ def main(argv: list[str] | None = None) -> int:
     report: dict[str, object] = {"apply": args.apply, "branches": [], "issues": [], "workflow_runs": {}}
 
     if args.branches:
-        for branch in list_agent_branches():
+        for branch in stale_branches_to_prune():
             if delete_branch(branch, apply=args.apply):
                 report["branches"].append(branch)
 

--- a/scripts/test-agent-helpers.sh
+++ b/scripts/test-agent-helpers.sh
@@ -36,3 +36,4 @@ run /usr/bin/python3 -m unittest scripts/test_release_gate_check.py
 run /usr/bin/python3 -m unittest scripts/test_automation_health_gate.py
 run /usr/bin/python3 -m unittest scripts/test_agent_stall_watchdog.py
 run /usr/bin/python3 -m unittest scripts/test_agent_approve_pr_ci.py
+run /usr/bin/python3 -m unittest scripts/test_repo_hygiene.py

--- a/scripts/test_repo_hygiene.py
+++ b/scripts/test_repo_hygiene.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Unit tests for repo hygiene branch pruning helpers."""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from repo_hygiene import KEEP_BRANCH_NAMES, is_prunable_branch
+
+
+class RepoHygieneBranchTest(unittest.TestCase):
+    def test_agent_branch_is_prunable(self) -> None:
+        self.assertTrue(is_prunable_branch("agent/issue-42-fix"))
+
+    def test_automation_branch_is_prunable(self) -> None:
+        self.assertTrue(is_prunable_branch("automation/pr-merge-retry"))
+
+    def test_main_is_not_prunable(self) -> None:
+        self.assertFalse(is_prunable_branch("main"))
+
+    def test_compat_sync_branch_is_kept(self) -> None:
+        self.assertIn("automation/compat-reports-sync", KEEP_BRANCH_NAMES)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- **Repo Hygiene** now prunes stale `agent/*` and `automation/*` branches (no open PR), keeping only `automation/compat-reports-sync`.
- **Agent Merge Cleanup** deletes merged `automation/*` branches immediately after squash merge.

## Test plan
- [ ] Unit tests pass
- [ ] `python3 scripts/repo_hygiene.py --branches` lists only stale branches
- [ ] After merge, weekly hygiene + merge cleanup keep branch count low


Made with [Cursor](https://cursor.com)