### PR TITLE
chore(release): cut CHANGELOG for v0.1.87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.87] - 2026-07-15
+
 ### Added
 
 - Release automation tags when `main` has unreleased commits, not only `awaiting-release` issues.


### PR DESCRIPTION
## Summary
- Move Unreleased notes under \`[0.1.87]\` after the tag published.
- Direct push from release housekeeping was blocked by branch protection (#182 path).

## Test plan
- [x] Confirm release https://github.com/kalebharrison/terraform-provider-dockhand/releases/tag/v0.1.87 is published
- [ ] Auto-merge when checks pass

Made with [Cursor](https://cursor.com)