### PR TITLE
fix(agent): issue 115 feature add environment public ip attribute

### DIFF
--- a/docs/reports/agent-review-log.md
+++ b/docs/reports/agent-review-log.md
@@ -824,3 +824,60 @@ Append-only record of lens sweeps. See `docs/AGENT_REVIEW_LENSES.md`.
 - **Blocking findings:** none
 - **Deferred medium/low:** probe fixture 404 tuning; backup API routes for future provider expansion; shrink `manifestOperationExemptions`; registry-and-image `timestamp()` example; README version pin bump; optional artifact scrubbing and auth error sanitization — carry forward from v0.1.85/v0.1.86/v0.1.87 (no new high-severity regressions)
 
+---
+
+## Issue #115 — [Feature]: Add environment public IP attribute
+
+### 2026-07-21 — Acceptance & regression
+
+**Scope:** `internal/provider/resource_environment_test.go`, `internal/provider/resource_environment_tf_acc_test.go`, `internal/provider/testdata/acceptance_manifest.json`, `internal/provider/testdata/acceptance_pr_ci.json`.
+
+**Summary:** Unit tests cover payload mapping, empty default on read, and API round-trip for `public_ip`. Acceptance suites exercise environment create/update/import but do not assert `public_ip` explicitly; manifest and PR CI regex coverage remain valid.
+
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| low | `internal/provider/resource_environment_tf_acc_test.go` | No acceptance assertion for `public_ip` create/read/update | Optional follow-up: add `TestCheckResourceAttr` when Dockhand exposes stable public IP in harness |
+| — | `internal/provider/resource_environment_test.go:197-243` | Unit tests for payload + empty default + API value | Satisfied |
+| — | `internal/provider/testdata/acceptance_manifest.json:21` | `dockhand_environment` manifest row with `TestAccEnvironmentResource` regex | Satisfied |
+
+---
+
+### 2026-07-21 — Terraform schema & state
+
+**Scope:** `internal/provider/resource_environment.go`, `internal/provider/data_source_environments.go`, `internal/provider/client_types.go`.
+
+**Summary:** `public_ip` is Optional+Computed with empty-string default via `environmentPublicIPValue`. Create/update payloads send `publicIp` (including empty string when unset). Read and list data source preserve API values or default to `""`. No high-severity schema or state issues.
+
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| — | `internal/provider/resource_environment.go:146-150` | Optional+Computed schema with MarkdownDescription | Satisfied |
+| — | `internal/provider/resource_environment.go:426-429,608-613` | Payload mapping + empty default helper | Satisfied |
+| — | `internal/provider/data_source_environments.go:152` | List data source uses same empty default | Satisfied |
+
+---
+
+### 2026-07-21 — GitOps / IaC practitioner
+
+**Scope:** `docs/resources/environment.md`, `examples/resources/dockhand_environment/resource.tf`, `docs/api-matrix.md`.
+
+**Summary:** Resource docs note empty default; api-matrix documents `public_ip` on create/read/update. Example HCL updated on this branch to show optional `public_ip`.
+
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| — | `docs/resources/environment.md`, `examples/resources/dockhand_environment/resource.tf` | Example shows `public_ip = ""` with comment | Fixed on branch |
+| low | `docs/data-sources/` | No dedicated `dockhand_environments` doc page | Pre-existing gap; defer |
+
+---
+
+### 2026-07-21 — Dockhand domain / runtime
+
+**Scope:** `internal/provider/resource_environment.go`, `internal/provider/client_types.go` (`publicIp` JSON), `docs/api-matrix.md`.
+
+**Summary:** Provider maps Terraform `public_ip` ↔ Dockhand API `publicIp` on create, update, read, and environments list. Empty default matches Dockhand UI behavior for unset public IP.
+
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| — | `internal/provider/client_types.go:552,578` | Typed `publicIp` on payload and response | Satisfied |
+| — | `docs/api-matrix.md:85-87` | Matrix notes `public_ip` on environment CRUD | Satisfied |
+| med | `internal/provider/resource_environment.go:377-456` | `direct`/`agent` field validation only on test action, not managed resource | Pre-existing (#115 scope); track in backlog |
+

--- a/docs/reports/agent-review-log.md
+++ b/docs/reports/agent-review-log.md
@@ -830,13 +830,14 @@ Append-only record of lens sweeps. See `docs/AGENT_REVIEW_LENSES.md`.
 
 ### 2026-07-21 — Acceptance & regression
 
-**Scope:** `internal/provider/resource_environment_test.go`, `internal/provider/resource_environment_tf_acc_test.go`, `internal/provider/testdata/acceptance_manifest.json`, `internal/provider/testdata/acceptance_pr_ci.json`.
+**Scope:** `internal/provider/resource_environment.go`, `internal/provider/resource_environment_test.go`, `internal/provider/resource_environment_tf_acc_test.go`, `internal/provider/testdata/acceptance_manifest.json`, `internal/provider/testdata/acceptance_pr_ci.json`.
 
-**Summary:** Unit tests cover payload mapping, empty default on read, and API round-trip for `public_ip`. Acceptance suites exercise environment create/update/import but do not assert `public_ip` explicitly; manifest and PR CI regex coverage remain valid.
+**Summary:** Core mapping landed in `dd74a82` (schema, payload, read default, unit tests). This branch adds an acceptance assertion that `public_ip` is `""` when omitted on create. Manifest and PR CI regex coverage remain valid.
 
 | Severity | Location | Finding | Suggested action |
 |----------|----------|---------|------------------|
-| low | `internal/provider/resource_environment_tf_acc_test.go` | No acceptance assertion for `public_ip` create/read/update | Optional follow-up: add `TestCheckResourceAttr` when Dockhand exposes stable public IP in harness |
+| med | `internal/provider/resource_environment_tf_acc_test.go` | No acceptance check for `public_ip` empty default before this branch | Fixed: `TestCheckResourceAttr(..., "public_ip", "")` on create |
+| low | `internal/provider/acceptance_manifest_test.go:34-60` | Residual `manifestOperationExemptions` unchanged | Shrink on future branches (deferred) |
 | — | `internal/provider/resource_environment_test.go:197-243` | Unit tests for payload + empty default + API value | Satisfied |
 | — | `internal/provider/testdata/acceptance_manifest.json:21` | `dockhand_environment` manifest row with `TestAccEnvironmentResource` regex | Satisfied |
 
@@ -846,13 +847,14 @@ Append-only record of lens sweeps. See `docs/AGENT_REVIEW_LENSES.md`.
 
 **Scope:** `internal/provider/resource_environment.go`, `internal/provider/data_source_environments.go`, `internal/provider/client_types.go`.
 
-**Summary:** `public_ip` is Optional+Computed with empty-string default via `environmentPublicIPValue`. Create/update payloads send `publicIp` (including empty string when unset). Read and list data source preserve API values or default to `""`. No high-severity schema or state issues.
+**Summary:** `public_ip` is Optional+Computed with empty-string default via `environmentPublicIPValue`. Create/update payloads send `publicIp` when plan or prior state is known (including explicit empty string). Read and list data source preserve API values or default to `""`. No high-severity schema or state issues.
 
 | Severity | Location | Finding | Suggested action |
 |----------|----------|---------|------------------|
 | — | `internal/provider/resource_environment.go:146-150` | Optional+Computed schema with MarkdownDescription | Satisfied |
 | — | `internal/provider/resource_environment.go:426-429,608-613` | Payload mapping + empty default helper | Satisfied |
 | — | `internal/provider/data_source_environments.go:152` | List data source uses same empty default | Satisfied |
+| low | `internal/provider/resource_environment.go:146-150` | No `UseStateForUnknown` on `public_ip` | Optional follow-up if plan noise reported (deferred) |
 
 ---
 
@@ -860,24 +862,26 @@ Append-only record of lens sweeps. See `docs/AGENT_REVIEW_LENSES.md`.
 
 **Scope:** `docs/resources/environment.md`, `examples/resources/dockhand_environment/resource.tf`, `docs/api-matrix.md`.
 
-**Summary:** Resource docs note empty default; api-matrix documents `public_ip` on create/read/update. Example HCL updated on this branch to show optional `public_ip`.
+**Summary:** Resource docs note empty default; api-matrix documents `public_ip` on create/read/update. Example and doc HCL show optional `public_ip = ""`.
 
 | Severity | Location | Finding | Suggested action |
 |----------|----------|---------|------------------|
 | — | `docs/resources/environment.md`, `examples/resources/dockhand_environment/resource.tf` | Example shows `public_ip = ""` with comment | Fixed on branch |
+| low | `docs/resources/environment.md` | No `## Schema` attribute list (unlike `network.md`) | Pre-existing gap; defer |
 | low | `docs/data-sources/` | No dedicated `dockhand_environments` doc page | Pre-existing gap; defer |
 
 ---
 
 ### 2026-07-21 — Dockhand domain / runtime
 
-**Scope:** `internal/provider/resource_environment.go`, `internal/provider/client_types.go` (`publicIp` JSON), `docs/api-matrix.md`.
+**Scope:** `internal/provider/resource_environment.go`, `internal/provider/client_types.go` (`publicIp` JSON), `internal/provider/data_source_environments.go`, `docs/api-matrix.md`.
 
 **Summary:** Provider maps Terraform `public_ip` ↔ Dockhand API `publicIp` on create, update, read, and environments list. Empty default matches Dockhand UI behavior for unset public IP.
 
 | Severity | Location | Finding | Suggested action |
 |----------|----------|---------|------------------|
 | — | `internal/provider/client_types.go:552,578` | Typed `publicIp` on payload and response | Satisfied |
+| — | `internal/provider/data_source_environments.go:76,152` | List data source exposes `public_ip` per environment | Satisfied |
 | — | `docs/api-matrix.md:85-87` | Matrix notes `public_ip` on environment CRUD | Satisfied |
 | med | `internal/provider/resource_environment.go:377-456` | `direct`/`agent` field validation only on test action, not managed resource | Pre-existing (#115 scope); track in backlog |
 

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -18,6 +18,7 @@ resource "dockhand_environment" "socket" {
   # client_cert = file("${path.module}/certs/client.pem")
   # client_key  = file("${path.module}/certs/client-key.pem")
   icon            = "globe"
+  public_ip       = "" # optional; defaults to empty string when unset
 
   collect_activity         = true
   collect_metrics          = true

--- a/examples/resources/dockhand_environment/resource.tf
+++ b/examples/resources/dockhand_environment/resource.tf
@@ -6,6 +6,7 @@ resource "dockhand_environment" "example" {
   protocol        = "http"
   tls_skip_verify = false
   icon            = "globe"
+  public_ip       = "" # optional; advertised public IP for this environment
 
   collect_activity                 = true
   collect_metrics                  = true

--- a/internal/provider/resource_environment_tf_acc_test.go
+++ b/internal/provider/resource_environment_tf_acc_test.go
@@ -43,6 +43,7 @@ func TestAccEnvironmentResourceDirectDinDTerraform(t *testing.T) {
 					resource.TestCheckResourceAttr("dockhand_environment.test", "port", "2375"),
 					resource.TestCheckResourceAttr("dockhand_environment.test", "protocol", "http"),
 					resource.TestCheckResourceAttr("dockhand_environment.test", "icon", "globe"),
+					resource.TestCheckResourceAttr("dockhand_environment.test", "public_ip", ""),
 					resource.TestCheckResourceAttrSet("dockhand_environment.test", "id"),
 					resource.TestCheckResourceAttr("dockhand_container.test", "name", containerName),
 					resource.TestCheckResourceAttrSet("dockhand_container.test", "id"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #115

## What was fixed

- **Problem:** `dockhand_environment` was missing the `public_ip` attribute that Dockhand exposes as `publicIp`.
- **Cause:** Provider schema and API mapping did not include the field.
- **Change:** Added `public_ip` (Optional+Computed) on `dockhand_environment` and computed `public_ip` on `dockhand_environments`, with empty-string default when unset. Updated docs, example HCL, unit tests, and acceptance assertion for the empty default.

## User impact

- **Who:** Operators managing Dockhand environments via Terraform.
- **Action required:** Upgrade to the release that includes this fix; optionally set `public_ip` on remote/direct environments.
- **Workaround until release:** None — field was unavailable in Terraform.

```hcl
resource "dockhand_environment" "edge" {
  name            = "remote-host"
  connection_type = "direct"
  host            = "docker.example.com"
  port            = 2375
  protocol        = "http"
  public_ip       = "203.0.113.10"
}
```

Omitting `public_ip` or setting `public_ip = ""` keeps the empty default, matching Dockhand UI behavior.

## Validation

- Required lens sweeps appended to `docs/reports/agent-review-log.md`
- `./scripts/verify.sh --quality` passes locally
- Unit tests: `TestBuildEnvironmentPayloadIncludesPublicIP`, `TestModelFromEnvironmentResponsePublicIPDefaultsEmpty`, `TestModelFromEnvironmentResponsePublicIPFromAPI`
- Acceptance: `TestAccEnvironmentResourceDirectDinDTerraform` asserts `public_ip = ""` on create
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a9b99de-dea2-4087-a1c5-453b04a43d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a9b99de-dea2-4087-a1c5-453b04a43d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

### Automation

- Validate run: https://github.com/kalebharrison/terraform-provider-dockhand/actions/runs/29795763412
- Branch: `agent/issue-115-feature-add-environment-public-ip-attribute`
- Head: `6ee83c96b5ec8a8855e9301bcfba0d284b7dbfe7`

Opened by the Agent Open PR workflow.