### PR TITLE
fix(ci): verify CURSOR_API_KEY via Cloud Agents, not Bugbot

### DIFF
--- a/.github/workflows/secret-smoke.yml
+++ b/.github/workflows/secret-smoke.yml
@@ -56,17 +56,17 @@ jobs:
             jq -r '.blockers[]?' /tmp/automation-settings.json >&2 || true
           fi
 
-      - name: Disable Cursor Bugbot for this repository
-        id: bugbot
-        if: steps.check.outputs.missing == 'false' && steps.settings.outputs.ok == 'true'
+      - name: Verify Cursor Cloud Agents API key
+        id: cursor_auth
+        if: steps.check.outputs.missing == 'false'
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
         shell: bash
         run: |
           set +e
-          /usr/bin/python3 scripts/cursor_bugbot_settings.py --disable --json \
-            > /tmp/bugbot-settings.json \
-            2> /tmp/bugbot-settings.err
+          /usr/bin/python3 scripts/cursor_cloud_agents_auth.py --json \
+            > /tmp/cursor-cloud-agents-auth.json \
+            2> /tmp/cursor-cloud-agents-auth.err
           status=$?
           set -euo pipefail
           if [[ "${status}" -eq 0 ]]; then
@@ -74,8 +74,32 @@ jobs:
             exit 0
           fi
           echo "ok=false" >> "${GITHUB_OUTPUT}"
+          if [[ -s /tmp/cursor-cloud-agents-auth.err ]]; then
+            sed 's/^/Cloud Agents API key check failed: /' /tmp/cursor-cloud-agents-auth.err >&2
+          fi
+
+      - name: Disable Cursor Bugbot for this repository (best-effort)
+        id: bugbot
+        if: steps.check.outputs.missing == 'false'
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+        shell: bash
+        run: |
+          # Bugbot admin API is Team/Enterprise-only. Solo / Pro+ user keys used for
+          # Cloud Agents intake commonly get "Invalid Team API Key" — that must not
+          # fail Secret Smoke or keep the secret health issue open.
+          set +e
+          /usr/bin/python3 scripts/cursor_bugbot_settings.py --disable --best-effort --json \
+            > /tmp/bugbot-settings.json \
+            2> /tmp/bugbot-settings.err
+          status=$?
+          set -euo pipefail
+          echo "ok=true" >> "${GITHUB_OUTPUT}"
           if [[ -s /tmp/bugbot-settings.err ]]; then
-            sed 's/^/Bugbot settings check failed: /' /tmp/bugbot-settings.err >&2
+            sed 's/^/Bugbot settings (best-effort): /' /tmp/bugbot-settings.err >&2
+          fi
+          if [[ "${status}" -ne 0 ]]; then
+            echo "Bugbot helper exited ${status}; ignoring (best-effort)" >&2
           fi
 
       - name: Open or close secret health issue
@@ -88,20 +112,20 @@ jobs:
             const repo = context.repo.repo;
             const title = "[Automation] Secret configuration required";
             const missing = "${{ steps.check.outputs.missing }}" === "true";
-            const bugbotChecked = "${{ steps.bugbot.conclusion }}" !== "skipped";
-            const bugbotOk = !bugbotChecked || "${{ steps.bugbot.outputs.ok }}" === "true";
+            const authChecked = "${{ steps.cursor_auth.conclusion }}" !== "skipped";
+            const authOk = !authChecked || "${{ steps.cursor_auth.outputs.ok }}" === "true";
             const missingSecrets = fs.existsSync("/tmp/missing-secrets.txt")
               ? fs.readFileSync("/tmp/missing-secrets.txt", "utf8").trim().split("\n").filter(Boolean)
               : [];
-            const bugbotError = fs.existsSync("/tmp/bugbot-settings.err")
-              ? fs.readFileSync("/tmp/bugbot-settings.err", "utf8").trim()
+            const authError = fs.existsSync("/tmp/cursor-cloud-agents-auth.err")
+              ? fs.readFileSync("/tmp/cursor-cloud-agents-auth.err", "utf8").trim()
               : "";
             const problems = [
               ...missingSecrets.map((name) => `- \`${name}\` is missing`),
             ];
-            if (!bugbotOk) {
-              const detail = bugbotError ? `: ${bugbotError}` : "";
-              problems.push(`- \`CURSOR_API_KEY\` failed Cursor Bugbot API verification${detail}`);
+            if (!authOk) {
+              const detail = authError ? `: ${authError}` : "";
+              problems.push(`- \`CURSOR_API_KEY\` failed Cursor Cloud Agents API verification (GET /v1/me)${detail}`);
             }
 
             const ensureLabel = async (name, color, description) => {
@@ -125,17 +149,20 @@ jobs:
               .filter((issue) => !issue.pull_request && issue.title === title)
               .sort((a, b) => b.number - a.number)[0];
 
-            if (missing || !bugbotOk) {
+            if (missing || !authOk) {
               const body = [
                 "## Problem",
                 "Automation secrets required for hands-off agent intake and signed releases are missing or invalid.",
                 "",
                 "## Done when",
                 "- Repository secrets are configured in GitHub Settings → Secrets and variables → Actions",
+                "- `CURSOR_API_KEY` authenticates to the Cloud Agents API (`GET https://api.cursor.com/v1/me`)",
                 "- **Secret Smoke** workflow succeeds on the next scheduled run",
                 "",
                 "## Problems",
                 ...problems,
+                "",
+                "Bugbot admin API access is optional (Team/Enterprise). Secret Smoke does not fail when Bugbot disable is unavailable for a user API key.",
                 "",
                 "This issue is managed automatically and closes when secrets verify successfully.",
               ].join("\n");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Secret Smoke**: validate `CURSOR_API_KEY` via Cloud Agents `GET /v1/me` instead of the Bugbot admin API; Bugbot disable is best-effort so non-team accounts no longer open a false secret-health issue.
+
 ### Added
 
 - _Nothing yet._

--- a/docs/AGENT_AUTONOMY.md
+++ b/docs/AGENT_AUTONOMY.md
@@ -98,7 +98,7 @@ When investigating manually:
 - Agents do not need VPN/home network access to your Dockhand.
 - Cloud Agents do not run DinD locally (`docs/AGENT_DEPLOYMENT.md`).
 - Maintainers are not a release gate — automation is.
-- **Cursor Bugbot** PR comments are disabled automatically — **Secret Smoke** calls `scripts/cursor_bugbot_settings.py --disable` weekly when `CURSOR_API_KEY` is configured. You can also turn off Bugbot manually at [cursor.com/dashboard/bugbot](https://cursor.com/dashboard/bugbot).
+- **Cursor Bugbot** PR comments are disabled when the Bugbot admin API is available — **Secret Smoke** calls `scripts/cursor_bugbot_settings.py --disable --best-effort` weekly. That API is Team/Enterprise-only; on solo/Pro+ accounts the step skips without failing (turn Bugbot off manually at [cursor.com/dashboard/bugbot](https://cursor.com/dashboard/bugbot) if needed). `CURSOR_API_KEY` validity is checked via Cloud Agents `GET /v1/me`, not Bugbot.
 
 ## Related docs
 

--- a/docs/AGENT_DEPLOYMENT.md
+++ b/docs/AGENT_DEPLOYMENT.md
@@ -43,13 +43,13 @@ gh api repos/kalebharrison/terraform-provider-dockhand/branches/main/protection 
 
 ## 2b. Configure Cursor API secret
 
-Add repository secret **`CURSOR_API_KEY`** (Cursor Dashboard → Integrations / API Keys).
+Add repository secret **`CURSOR_API_KEY`** (Cursor Dashboard → Cloud Agents / API Keys — a user API key is enough; Team/Enterprise is not required for intake).
 
 Without it, **Issue Agent Intake** fails fast with an actionable error. The rest of the agent loop (Validate, Open PR, Approve CI, Auto Merge) still works for manually pushed `agent/**` branches.
 
 Also enable **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests** (required for Agent Open PR and Agent Approve CI).
 
-**Secret Smoke** (weekly) verifies `CURSOR_API_KEY`, `GPG_PRIVATE_KEY`, workflow default permissions (`write`), PR approval setting, and disables Cursor Bugbot via `scripts/check_automation_settings.py` and `scripts/cursor_bugbot_settings.py`. A failed run means automation will stall until settings or secrets are corrected.
+**Secret Smoke** (weekly) verifies `CURSOR_API_KEY` against the Cloud Agents API (`GET /v1/me` via `scripts/cursor_cloud_agents_auth.py`), checks `GPG_PRIVATE_KEY` presence, and verifies workflow default permissions (`write`) / PR approval setting via `scripts/check_automation_settings.py`. It also attempts to disable Cursor Bugbot via `scripts/cursor_bugbot_settings.py --best-effort` — that call is optional (Bugbot admin API is Team/Enterprise-only) and never fails the smoke check. A failed run means automation will stall until settings or secrets are corrected.
 
 ## 3. Smoke test the loop (branch push)
 

--- a/docs/AGENT_INTAKE.md
+++ b/docs/AGENT_INTAKE.md
@@ -33,7 +33,7 @@ The workflow:
 
 **Agent Validate** requires an update to `docs/reports/agent-review-log.md` on the agent branch before acceptance tests run.
 
-**Required secret:** `CURSOR_API_KEY` (Cursor Dashboard → Integrations / API Keys). Add in GitHub **Settings → Secrets and variables → Actions**.
+**Required secret:** `CURSOR_API_KEY` (Cursor Dashboard → Cloud Agents / API Keys; a user key is enough). Add in GitHub **Settings → Secrets and variables → Actions**. **Secret Smoke** verifies it with Cloud Agents `GET /v1/me` (not the Bugbot admin API).
 
 After the agent pushes:
 

--- a/scripts/cursor_bugbot_settings.py
+++ b/scripts/cursor_bugbot_settings.py
@@ -15,6 +15,17 @@ ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_REPO_URL = "https://github.com/kalebharrison/terraform-provider-dockhand"
 API_URL = "https://api.cursor.com/bugbot/repo/update"
 
+# Bugbot admin API is Team/Enterprise-oriented. User API keys used for Cloud
+# Agents commonly receive "Invalid Team API Key" here; treat that as optional.
+_UNAVAILABLE_MARKERS = (
+    "invalid team api key",
+    "team api key",
+    "not a team",
+    "enterprise",
+    "http 401",
+    "http 403",
+)
+
 
 def _repo_url(explicit: str | None) -> str:
     if explicit:
@@ -62,6 +73,12 @@ def update_bugbot(
     return json.loads(body)
 
 
+def is_unavailable_error(err: BaseException) -> bool:
+    """Return True when Bugbot API rejects a non-team / non-admin key."""
+    text = str(err).lower()
+    return any(marker in text for marker in _UNAVAILABLE_MARKERS)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--enable", action="store_true")
@@ -69,6 +86,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--manual-trigger-only", action="store_true")
     parser.add_argument("--repo-url", default="")
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--best-effort",
+        action="store_true",
+        help=(
+            "Treat Bugbot API failures as skipped (exit 0). Use in Secret Smoke: "
+            "Bugbot admin API is Team/Enterprise-only; Cloud Agents user keys are enough."
+        ),
+    )
     args = parser.parse_args(argv)
 
     if args.enable == args.disable:
@@ -87,6 +112,20 @@ def main(argv: list[str] | None = None) -> int:
             manual_trigger_only=True if args.manual_trigger_only else None,
         )
     except RuntimeError as err:
+        if args.best_effort:
+            payload = {
+                "skipped": True,
+                "reason": str(err),
+                "unavailable": is_unavailable_error(err),
+            }
+            print(
+                "Bugbot API unavailable or failed; skipping "
+                f"(best-effort): {err}",
+                file=sys.stderr,
+            )
+            if args.json:
+                print(json.dumps(payload, indent=2))
+            return 0
         print(str(err), file=sys.stderr)
         return 1
 

--- a/scripts/cursor_cloud_agents_auth.py
+++ b/scripts/cursor_cloud_agents_auth.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Verify CURSOR_API_KEY against the Cursor Cloud Agents API (GET /v1/me)."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+ME_URL = "https://api.cursor.com/v1/me"
+
+
+def verify_api_key(api_key: str) -> dict:
+    """Return API key metadata from GET /v1/me.
+
+    Uses Basic auth with the API key as the username (empty password), matching
+    Issue Agent Intake and the Cloud Agents API docs.
+    """
+    request = urllib.request.Request(
+        ME_URL,
+        method="GET",
+        headers={
+            "Authorization": "Basic "
+            + base64.b64encode(f"{api_key}:".encode()).decode(),
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as err:
+        detail = err.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Cloud Agents API HTTP {err.code}: {detail}") from err
+    except urllib.error.URLError as err:
+        raise RuntimeError(f"Cloud Agents API request failed: {err}") from err
+
+    if not body.strip():
+        return {"ok": True}
+    payload = json.loads(body)
+    if not isinstance(payload, dict):
+        raise RuntimeError("Cloud Agents API returned a non-object JSON body")
+    return payload
+
+
+def _public_summary(payload: dict) -> dict:
+    """Strip PII fields from /v1/me for safer CI logs."""
+    return {
+        "ok": True,
+        "apiKeyName": payload.get("apiKeyName"),
+        "createdAt": payload.get("createdAt"),
+        "userId": payload.get("userId"),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    api_key = os.environ.get("CURSOR_API_KEY", "").strip()
+    if not api_key:
+        print("CURSOR_API_KEY is not set", file=sys.stderr)
+        return 2
+
+    try:
+        result = verify_api_key(api_key)
+    except RuntimeError as err:
+        print(str(err), file=sys.stderr)
+        return 1
+
+    summary = _public_summary(result)
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        name = summary.get("apiKeyName") or "(unnamed)"
+        print(f"CURSOR_API_KEY ok for Cloud Agents API (key={name})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-agent-helpers.sh
+++ b/scripts/test-agent-helpers.sh
@@ -38,3 +38,5 @@ run /usr/bin/python3 -m unittest scripts/test_agent_stall_watchdog.py
 run /usr/bin/python3 -m unittest scripts/test_agent_approve_pr_ci.py
 run /usr/bin/python3 -m unittest scripts/test_repo_hygiene.py
 run /usr/bin/python3 -m unittest scripts/test_check_automation_settings.py
+run /usr/bin/python3 -m unittest scripts/test_cursor_cloud_agents_auth.py
+run /usr/bin/python3 -m unittest scripts/test_cursor_bugbot_settings.py

--- a/scripts/test_cursor_bugbot_settings.py
+++ b/scripts/test_cursor_bugbot_settings.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Unit tests for Bugbot settings helper."""
+
+from __future__ import annotations
+
+import io
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import cursor_bugbot_settings as bugbot
+
+
+class CursorBugbotSettingsTest(unittest.TestCase):
+    def test_unavailable_error_detection(self) -> None:
+        self.assertTrue(
+            bugbot.is_unavailable_error(
+                RuntimeError('Bugbot API HTTP 401: {"message":"Invalid Team API Key"}')
+            )
+        )
+        self.assertTrue(
+            bugbot.is_unavailable_error(RuntimeError("Bugbot API HTTP 403: forbidden"))
+        )
+        self.assertFalse(
+            bugbot.is_unavailable_error(RuntimeError("Bugbot API request failed: timeout"))
+        )
+
+    @mock.patch.object(bugbot, "update_bugbot")
+    @mock.patch.dict(bugbot.os.environ, {"CURSOR_API_KEY": "k"}, clear=True)
+    def test_best_effort_skips_team_key_errors(self, update: mock.Mock) -> None:
+        update.side_effect = RuntimeError(
+            'Bugbot API HTTP 401: {"message":"Invalid Team API Key"}'
+        )
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            with mock.patch("sys.stderr", new_callable=io.StringIO) as err:
+                code = bugbot.main(["--disable", "--best-effort", "--json"])
+        self.assertEqual(code, 0)
+        self.assertIn('"skipped": true', out.getvalue())
+        self.assertIn("Bugbot API unavailable", err.getvalue())
+
+    @mock.patch.object(bugbot, "update_bugbot")
+    @mock.patch.dict(bugbot.os.environ, {"CURSOR_API_KEY": "k"}, clear=True)
+    def test_best_effort_skips_other_errors(self, update: mock.Mock) -> None:
+        update.side_effect = RuntimeError("Bugbot API request failed: timeout")
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            code = bugbot.main(["--disable", "--best-effort", "--json"])
+        self.assertEqual(code, 0)
+        self.assertIn('"skipped": true', out.getvalue())
+
+    @mock.patch.object(bugbot, "update_bugbot")
+    @mock.patch.dict(bugbot.os.environ, {"CURSOR_API_KEY": "k"}, clear=True)
+    def test_strict_mode_fails_team_key_errors(self, update: mock.Mock) -> None:
+        update.side_effect = RuntimeError(
+            'Bugbot API HTTP 401: {"message":"Invalid Team API Key"}'
+        )
+        with mock.patch("sys.stderr", new_callable=io.StringIO):
+            code = bugbot.main(["--disable", "--json"])
+        self.assertEqual(code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_cursor_cloud_agents_auth.py
+++ b/scripts/test_cursor_cloud_agents_auth.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Unit tests for Cloud Agents API key verification."""
+
+from __future__ import annotations
+
+import io
+import pathlib
+import sys
+import unittest
+import urllib.error
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import cursor_cloud_agents_auth as auth
+
+
+class CursorCloudAgentsAuthTest(unittest.TestCase):
+    @mock.patch.object(auth.urllib.request, "urlopen")
+    def test_verify_api_key_success(self, urlopen: mock.Mock) -> None:
+        response = mock.MagicMock()
+        response.read.return_value = (
+            b'{"apiKeyName":"ci","userId":1,"userEmail":"a@example.com",'
+            b'"createdAt":"2026-01-01T00:00:00.000Z"}'
+        )
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+        urlopen.return_value = response
+
+        result = auth.verify_api_key("test-key")
+
+        self.assertEqual(result["apiKeyName"], "ci")
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.full_url, auth.ME_URL)
+        self.assertTrue(request.get_header("Authorization").startswith("Basic "))
+
+    @mock.patch.object(auth.urllib.request, "urlopen")
+    def test_verify_api_key_http_error(self, urlopen: mock.Mock) -> None:
+        err = urllib.error.HTTPError(
+            auth.ME_URL, 401, "Unauthorized", hdrs=None, fp=io.BytesIO(b"bad key")
+        )
+        urlopen.side_effect = err
+
+        with self.assertRaisesRegex(RuntimeError, "Cloud Agents API HTTP 401"):
+            auth.verify_api_key("bad")
+
+    @mock.patch.dict(auth.os.environ, {}, clear=True)
+    def test_main_missing_key(self) -> None:
+        self.assertEqual(auth.main(["--json"]), 2)
+
+    @mock.patch.object(auth, "verify_api_key")
+    @mock.patch.dict(auth.os.environ, {"CURSOR_API_KEY": "k"}, clear=True)
+    def test_main_redacts_email(self, verify: mock.Mock) -> None:
+        verify.return_value = {
+            "apiKeyName": "ci",
+            "userEmail": "secret@example.com",
+            "userId": 9,
+            "createdAt": "2026-01-01T00:00:00.000Z",
+        }
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            code = auth.main(["--json"])
+        self.assertEqual(code, 0)
+        printed = out.getvalue()
+        self.assertNotIn("secret@example.com", printed)
+        self.assertIn('"apiKeyName": "ci"', printed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Related to #213

## Summary

- Secret Smoke no longer treats Bugbot admin API failures as an invalid `CURSOR_API_KEY`
- Key validity is checked with Cloud Agents `GET /v1/me` (works for user/Pro+ keys)
- Bugbot disable is best-effort / optional (Team/Enterprise-only)

## What was fixed

- **Problem:** Secret Smoke opened `#213` because `CURSOR_API_KEY` failed Bugbot with `Invalid Team API Key`, even though the same user key works for Cloud Agents intake and Bugbot is already off in the dashboard.
- **Cause:** Bugbot’s `/bugbot/repo/update` API expects a Team/Enterprise admin key; Cloud Agents intake only needs a user API key.
- **Change:** Add `scripts/cursor_cloud_agents_auth.py` (`GET /v1/me`); gate the secret-health issue on that check; run Bugbot disable with `--best-effort` so skips never fail smoke or keep the tracker open.

## User impact

- **Who:** Maintainers running autonomous agent intake without a Cursor Team plan
- **Action required:** Merge, then re-run **Secret Smoke** (`workflow_dispatch`) — it should pass and auto-close `#213`
- **Workaround until release:** Ignore `#213` / keep Bugbot off in the dashboard (already the case)

## Validation

- [x] `/usr/bin/python3 -m unittest scripts/test_cursor_cloud_agents_auth.py scripts/test_cursor_bugbot_settings.py`
- [ ] Re-run **Secret Smoke** after merge to close `#213`

## Release Notes

- [x] No user-facing provider behavior change (CI/docs only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c4b38d3-eda8-42b6-910e-4156a394dfd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c4b38d3-eda8-42b6-910e-4156a394dfd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

