### PR TITLE
fix(ci): stop compat-sync PR email loop

### DIFF
--- a/.github/workflows/compat-reports-sync.yml
+++ b/.github/workflows/compat-reports-sync.yml
@@ -108,6 +108,14 @@ jobs:
             exit 0
           fi
 
+          # Skip timestamp/source_run/Date-only churn — that loop opens a PR every
+          # Release Watch cycle and floods watching maintainer email.
+          if ! /usr/bin/python3 scripts/compat_reports_changed.py --check-working-tree; then
+            echo "Compatibility reports have no substantive changes (volatile metadata only)."
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
           git add docs/reports docs/non-present-endpoints.md
           git -c user.name='github-actions[bot]' \
             -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \

--- a/.github/workflows/dockhand-release-watch.yml
+++ b/.github/workflows/dockhand-release-watch.yml
@@ -34,6 +34,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # Need history to ignore docs-only compat-sync commits when deciding skip.
+          fetch-depth: 0
 
       - name: Restore watch state cache
         uses: actions/cache/restore@v6

--- a/docs/AGENT_AUTONOMY.md
+++ b/docs/AGENT_AUTONOMY.md
@@ -59,6 +59,7 @@ After a green **Acceptance Full** or **Dockhand Release Watch** run:
 1. Harness probes ephemeral Dockhand (`scripts/endpoint-probe.py`, webui/docs audits).
 2. Workflow uploads artifact `compat-reports-sync`.
 3. **Compat Reports Sync** commits refreshed baselines to `main` when branch rules allow; otherwise it opens one shared auto-merge PR (`automation/compat-reports-sync`), approves blocked checks, and merges without a maintainer. Those PRs are labeled `compat-reports-sync` + `skip-changelog` so **Release Drafter** omits them from release notes.
+4. Sync is a **no-op** when only volatile metadata changed (`updated_at` / `source_run` / the non-present `- Date:` line). **Dockhand Release Watch** also skips re-validation when `main` advanced only via prior compat-sync commits (same Dockhand digest).
 
 No manual merge or workflow approval is required for routine report refresh.
 

--- a/scripts/compat_reports_changed.py
+++ b/scripts/compat_reports_changed.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Detect substantive Compat Reports Sync changes (ignore volatile metadata)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TRACKED_RELPATHS = (
+    "docs/reports/endpoint-probe.md",
+    "docs/reports/endpoint-probe.csv",
+    "docs/reports/webui-api-endpoints.txt",
+    "docs/reports/docs-reference-api-endpoints.txt",
+    "docs/reports/dockhand-last-tested.json",
+    "docs/non-present-endpoints.md",
+)
+VOLATILE_JSON_KEYS = frozenset({"updated_at", "source_run"})
+DATE_LINE_RE = re.compile(r"(?m)^- Date: .*$")
+
+
+def normalize_content(relpath: str, text: str) -> str:
+    """Strip fields that change every green CI run without real baseline drift."""
+    name = Path(relpath).name
+    if name == "dockhand-last-tested.json":
+        data = json.loads(text) if text.strip() else {}
+        if not isinstance(data, dict):
+            return text
+        for key in VOLATILE_JSON_KEYS:
+            data.pop(key, None)
+        return json.dumps(data, sort_keys=True, indent=2) + "\n"
+    if name == "non-present-endpoints.md":
+        return DATE_LINE_RE.sub("- Date: <normalized>", text)
+    return text
+
+
+def _git_show(repo: Path, rev: str, relpath: str) -> str | None:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "show", f"{rev}:{relpath}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def substantive_paths_changed(
+    *,
+    repo: Path = ROOT,
+    base_rev: str = "HEAD",
+    relpaths: tuple[str, ...] = TRACKED_RELPATHS,
+) -> list[str]:
+    """Return tracked paths whose normalized content differs from base_rev."""
+    changed: list[str] = []
+    for relpath in relpaths:
+        path = repo / relpath
+        if path.is_file():
+            working = path.read_text(encoding="utf-8")
+        else:
+            working = None
+        base = _git_show(repo, base_rev, relpath)
+        if working is None and base is None:
+            continue
+        if working is None or base is None:
+            changed.append(relpath)
+            continue
+        if normalize_content(relpath, working) != normalize_content(relpath, base):
+            changed.append(relpath)
+    return changed
+
+
+def restore_tracked_files(*, repo: Path = ROOT, relpaths: tuple[str, ...] = TRACKED_RELPATHS) -> None:
+    """Discard working-tree edits for tracked sync paths."""
+    subprocess.run(
+        ["git", "-C", str(repo), "checkout", "--", *relpaths],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check-working-tree",
+        action="store_true",
+        help="Exit 0 if substantive changes vs HEAD; 1 if metadata-only/no-op. "
+        "Restores tracked files when unchanged.",
+    )
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--repo", type=Path, default=ROOT)
+    parser.add_argument("--base-rev", default="HEAD")
+    args = parser.parse_args(argv)
+
+    if not args.check_working_tree:
+        parser.error("pass --check-working-tree")
+
+    changed = substantive_paths_changed(repo=args.repo, base_rev=args.base_rev)
+    payload = {"changed": bool(changed), "paths": changed}
+    if args.json:
+        print(json.dumps(payload))
+    else:
+        if changed:
+            print(f"substantive compat report changes: {', '.join(changed)}")
+        else:
+            print("compat reports unchanged after normalizing volatile metadata")
+
+    if not changed:
+        restore_tracked_files(repo=args.repo)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_watch_state.py
+++ b/scripts/release_watch_state.py
@@ -5,14 +5,18 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
 STATE_DIR = Path(".ci-state/dockhand-release-watch")
 STATE_FILE = STATE_DIR / "state.env"
+
+COMPAT_SYNC_SUBJECT = "chore: refresh compatibility reports from CI"
+COMPAT_PATH_PREFIXES = ("docs/reports/",)
+COMPAT_EXACT_PATHS = frozenset({"docs/non-present-endpoints.md"})
 
 
 def _parse_env_file(text: str) -> dict[str, str]:
@@ -62,6 +66,93 @@ def parse_legacy_issue_body(body: str) -> dict[str, str]:
     return out
 
 
+def is_compat_sync_subject(subject: str) -> bool:
+    """True for squash/merge subjects from Compat Reports Sync."""
+    text = subject.strip()
+    if text == COMPAT_SYNC_SUBJECT:
+        return True
+    # Squash merge: "chore: refresh compatibility reports from CI (#235)"
+    if text.startswith(COMPAT_SYNC_SUBJECT + " ("):
+        return True
+    return False
+
+
+def is_compat_only_paths(paths: list[str]) -> bool:
+    """True when every touched path is a docs baseline Compat Reports Sync may update."""
+    if not paths:
+        return False
+    for path in paths:
+        normalized = path.strip().lstrip("./")
+        if not normalized:
+            continue
+        if normalized in COMPAT_EXACT_PATHS:
+            continue
+        if any(normalized.startswith(prefix) for prefix in COMPAT_PATH_PREFIXES):
+            continue
+        return False
+    return True
+
+
+def is_compat_only_commit(subject: str, paths: list[str]) -> bool:
+    """Ignore docs-only sync commits when deciding whether provider main changed."""
+    if is_compat_sync_subject(subject):
+        return True
+    return is_compat_only_paths(paths)
+
+
+def has_substantive_provider_commits(commits: list[tuple[str, list[str]]]) -> bool:
+    """True if any intervening commit is not a compat-reports sync."""
+    return any(not is_compat_only_commit(subject, paths) for subject, paths in commits)
+
+
+def list_commits_between(
+    last_sha: str,
+    main_sha: str,
+    *,
+    repo: Path | None = None,
+) -> list[tuple[str, list[str]]] | None:
+    """Return (subject, paths) for commits in last_sha..main_sha, or None on git failure."""
+    if not last_sha or not main_sha or last_sha == main_sha:
+        return []
+    cwd = str(repo) if repo is not None else None
+    proc = subprocess.run(
+        [
+            "git",
+            "log",
+            "--format=%H%x00%s",
+            "--name-only",
+            f"{last_sha}..{main_sha}",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    if proc.returncode != 0:
+        return None
+
+    commits: list[tuple[str, list[str]]] = []
+    current_subject: str | None = None
+    current_paths: list[str] = []
+    for raw in proc.stdout.splitlines():
+        line = raw.strip("\r")
+        if "\x00" in line:
+            if current_subject is not None:
+                commits.append((current_subject, current_paths))
+            _sha, subject = line.split("\x00", 1)
+            current_subject = subject
+            current_paths = []
+            continue
+        if not line:
+            continue
+        if current_subject is None:
+            continue
+        current_paths.append(line)
+    if current_subject is not None:
+        commits.append((current_subject, current_paths))
+    return commits
+
+
 def decide_should_run(
     *,
     tag: str,
@@ -71,6 +162,8 @@ def decide_should_run(
     force_validate: bool,
     manual_image_tag: bool,
     main_sha: str,
+    intervening_commits: list[tuple[str, list[str]]] | None = None,
+    git_repo: Path | None = None,
 ) -> tuple[bool, str]:
     last_tag = state.get("last_tag", "")
     last_digest = state.get("last_digest", "")
@@ -89,7 +182,15 @@ def decide_should_run(
     if digest and not last_digest:
         return True, "state_missing_digest"
     if main_sha and last_provider_sha and main_sha != last_provider_sha:
-        return True, "provider_main_changed"
+        commits = intervening_commits
+        if commits is None:
+            commits = list_commits_between(last_provider_sha, main_sha, repo=git_repo)
+        if commits is None:
+            # Unknown history — keep previous fail-open behavior.
+            return True, "provider_main_changed"
+        if has_substantive_provider_commits(commits):
+            return True, "provider_main_changed"
+        # Only compat-report sync commits advanced main; treat like unchanged digest.
 
     unchanged = (digest and last_digest and digest == last_digest) or (
         not digest or not last_digest
@@ -113,6 +214,12 @@ def main(argv: list[str] | None = None) -> int:
     decide.add_argument("--manual-image-tag", action="store_true")
     decide.add_argument("--main-sha", default="")
     decide.add_argument("--state-file", type=Path, default=STATE_FILE)
+    decide.add_argument(
+        "--git-repo",
+        type=Path,
+        default=None,
+        help="Repo root for walking last_provider_sha..main_sha (default: cwd)",
+    )
 
     write = sub.add_parser("write", help="Write state.env")
     write.add_argument("--tag", required=True)
@@ -134,6 +241,7 @@ def main(argv: list[str] | None = None) -> int:
             force_validate=args.force_validate,
             manual_image_tag=args.manual_image_tag,
             main_sha=args.main_sha,
+            git_repo=args.git_repo,
         )
         payload = {
             "should_run": should_run,

--- a/scripts/test-agent-helpers.sh
+++ b/scripts/test-agent-helpers.sh
@@ -33,6 +33,8 @@ run /usr/bin/python3 -m unittest scripts/test_issue_agent_intake_eligibility.py
 run /usr/bin/python3 -m unittest scripts/test_issue_agent_intake_lenses.py
 run /usr/bin/python3 -m unittest scripts/test_release_verdict.py
 run /usr/bin/python3 -m unittest scripts/test_release_gate_check.py
+run /usr/bin/python3 -m unittest scripts/test_release_watch_state.py
+run /usr/bin/python3 -m unittest scripts/test_compat_reports_changed.py
 run /usr/bin/python3 -m unittest scripts/test_automation_health_gate.py
 run /usr/bin/python3 -m unittest scripts/test_agent_stall_watchdog.py
 run /usr/bin/python3 -m unittest scripts/test_agent_approve_pr_ci.py

--- a/scripts/test_compat_reports_changed.py
+++ b/scripts/test_compat_reports_changed.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Unit tests for Compat Reports Sync substantive-change detection."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import compat_reports_changed as crc
+
+
+class CompatReportsChangedTest(unittest.TestCase):
+    def test_normalize_strips_volatile_json_keys(self) -> None:
+        raw = json.dumps(
+            {
+                "digest": "sha256:abc",
+                "image": "fnsys/dockhand:latest",
+                "updated_at": "2026-07-23T08:47:46Z",
+                "source_run": "https://example/run/1",
+                "tag": "latest",
+            }
+        )
+        normalized = crc.normalize_content("docs/reports/dockhand-last-tested.json", raw)
+        data = json.loads(normalized)
+        self.assertEqual(data["digest"], "sha256:abc")
+        self.assertNotIn("updated_at", data)
+        self.assertNotIn("source_run", data)
+
+    def test_normalize_date_line_in_non_present(self) -> None:
+        text = "# Non-present\n\n- Date: July 22, 2026 (CI Acceptance Full / Release Watch)\n- Other: keep\n"
+        a = crc.normalize_content("docs/non-present-endpoints.md", text)
+        b = crc.normalize_content(
+            "docs/non-present-endpoints.md",
+            text.replace("July 22, 2026", "July 23, 2026"),
+        )
+        self.assertEqual(a, b)
+        self.assertIn("- Other: keep", a)
+
+    def test_normalize_leaves_probe_body(self) -> None:
+        text = "# probe\nroute A\n"
+        self.assertEqual(crc.normalize_content("docs/reports/endpoint-probe.md", text), text)
+
+    def test_substantive_paths_changed_ignores_metadata_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            reports = repo / "docs" / "reports"
+            reports.mkdir(parents=True)
+            (repo / "docs").mkdir(exist_ok=True)
+
+            base_json = {
+                "digest": "sha256:same",
+                "image": "fnsys/dockhand:latest",
+                "tag": "latest",
+                "updated_at": "2026-07-22T00:00:00Z",
+                "source_run": "https://example/old",
+            }
+            new_json = dict(base_json)
+            new_json["updated_at"] = "2026-07-23T00:00:00Z"
+            new_json["source_run"] = "https://example/new"
+
+            json_path = reports / "dockhand-last-tested.json"
+            json_path.write_text(json.dumps(base_json, indent=2) + "\n", encoding="utf-8")
+            non_present = repo / "docs" / "non-present-endpoints.md"
+            non_present.write_text(
+                "- Date: July 22, 2026 (CI Acceptance Full / Release Watch)\n",
+                encoding="utf-8",
+            )
+            probe = reports / "endpoint-probe.md"
+            probe.write_text("stable probe\n", encoding="utf-8")
+
+            # Fake HEAD via a "base" file store by monkeypatching _git_show.
+            base_files = {
+                "docs/reports/dockhand-last-tested.json": json_path.read_text(encoding="utf-8"),
+                "docs/non-present-endpoints.md": non_present.read_text(encoding="utf-8"),
+                "docs/reports/endpoint-probe.md": probe.read_text(encoding="utf-8"),
+            }
+
+            def fake_show(_repo: Path, _rev: str, relpath: str) -> str | None:
+                return base_files.get(relpath)
+
+            # Metadata-only edits in working tree.
+            json_path.write_text(json.dumps(new_json, indent=2) + "\n", encoding="utf-8")
+            non_present.write_text(
+                "- Date: July 23, 2026 (CI Acceptance Full / Release Watch)\n",
+                encoding="utf-8",
+            )
+
+            original = crc._git_show
+            crc._git_show = fake_show  # type: ignore[assignment]
+            try:
+                self.assertEqual(
+                    crc.substantive_paths_changed(repo=repo, base_rev="HEAD"),
+                    [],
+                )
+                # Digests diverge → substantive.
+                new_json["digest"] = "sha256:other"
+                json_path.write_text(json.dumps(new_json, indent=2) + "\n", encoding="utf-8")
+                self.assertEqual(
+                    crc.substantive_paths_changed(repo=repo, base_rev="HEAD"),
+                    ["docs/reports/dockhand-last-tested.json"],
+                )
+            finally:
+                crc._git_show = original  # type: ignore[assignment]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release_watch_state.py
+++ b/scripts/test_release_watch_state.py
@@ -58,9 +58,85 @@ class ReleaseWatchStateTest(unittest.TestCase):
             force_validate=False,
             manual_image_tag=False,
             main_sha="newsha",
+            intervening_commits=[
+                ("fix(provider): real change", ["internal/provider/provider.go"]),
+            ],
         )
         self.assertTrue(should_run)
         self.assertEqual(reason, "provider_main_changed")
+
+    def test_decide_skips_when_only_compat_sync_commits(self) -> None:
+        should_run, reason = state.decide_should_run(
+            tag="1.0.0",
+            digest="sha256:abc",
+            state={
+                "last_tag": "1.0.0",
+                "last_digest": "sha256:abc",
+                "last_provider_sha": "oldsha",
+            },
+            event_name="schedule",
+            force_validate=False,
+            manual_image_tag=False,
+            main_sha="newsha",
+            intervening_commits=[
+                (
+                    "chore: refresh compatibility reports from CI (#235)",
+                    ["docs/reports/dockhand-last-tested.json"],
+                ),
+                (
+                    "chore: refresh compatibility reports from CI",
+                    [
+                        "docs/reports/endpoint-probe.md",
+                        "docs/non-present-endpoints.md",
+                    ],
+                ),
+            ],
+        )
+        self.assertFalse(should_run)
+        self.assertEqual(reason, "unchanged_tag_digest")
+
+    def test_decide_provider_changed_mixed_with_compat(self) -> None:
+        should_run, reason = state.decide_should_run(
+            tag="1.0.0",
+            digest="sha256:abc",
+            state={
+                "last_tag": "1.0.0",
+                "last_digest": "sha256:abc",
+                "last_provider_sha": "oldsha",
+            },
+            event_name="schedule",
+            force_validate=False,
+            manual_image_tag=False,
+            main_sha="newsha",
+            intervening_commits=[
+                (
+                    "chore: refresh compatibility reports from CI (#230)",
+                    ["docs/reports/dockhand-last-tested.json"],
+                ),
+                ("chore: bump golang.org/x/text", ["go.mod", "go.sum"]),
+            ],
+        )
+        self.assertTrue(should_run)
+        self.assertEqual(reason, "provider_main_changed")
+
+    def test_is_compat_only_helpers(self) -> None:
+        self.assertTrue(state.is_compat_sync_subject("chore: refresh compatibility reports from CI"))
+        self.assertTrue(
+            state.is_compat_sync_subject("chore: refresh compatibility reports from CI (#235)")
+        )
+        self.assertFalse(state.is_compat_sync_subject("chore: something else"))
+        self.assertTrue(
+            state.is_compat_only_paths(
+                ["docs/reports/endpoint-probe.md", "docs/non-present-endpoints.md"]
+            )
+        )
+        self.assertFalse(state.is_compat_only_paths(["docs/reports/x.md", "go.mod"]))
+        self.assertTrue(
+            state.is_compat_only_commit(
+                "docs: unrelated title",
+                ["docs/reports/dockhand-last-tested.json"],
+            )
+        )
 
     def test_decide_schedule_skips_when_unchanged(self) -> None:
         stale = (datetime.now(timezone.utc) - timedelta(days=8)).strftime("%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stop the every-few-hours `chore: refresh compatibility reports from CI` watching emails.

- **Compat Reports Sync** skips commit/PR when only volatile metadata changed (`updated_at` / `source_run` / non-present `- Date:`).
- **Dockhand Release Watch** ignores docs-only compat-sync commits when deciding `provider_main_changed`, so the 6h schedule can skip when the Dockhand digest is unchanged.
- Discover job uses full git history for that walk.

## What was fixed

- **Problem:** Watching maintainers got a flood of `Re: … chore: refresh compatibility reports from CI` emails.
- **Cause:** Timestamp-only sync PRs changed `main` SHA → Release Watch revalidated → another sync PR, every ~6 hours. Direct push to `main` is blocked by branch protection, so fallback PRs notified watchers.
- **Change:** Metadata-normalized no-op detection + ignore compat-only intervening commits in release-watch skip logic.

## User impact

- **Who:** Repo watchers / maintainers receiving GitHub PR emails
- **Action required:** none for provider users
- **Workaround until release:** n/a (CI only)

## Test plan

- [x] `python3 -m unittest scripts/test_compat_reports_changed.py scripts/test_release_watch_state.py`
- [x] `./scripts/verify.sh --quality`
- [ ] After merge: next Release Watch schedule should skip when digest unchanged; no new compat-sync PR unless probe/digest content actually changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e58d934-56ad-42da-a289-5eef0afb83ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e58d934-56ad-42da-a289-5eef0afb83ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

