### PR TITLE
fix(provider): require webhook secret when webhook enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `dockhand_git_stack`: when `webhook_enabled=true`, require `webhook_secret` or `webhook_secret_auto_generate=true` (Dockhand rejects an empty secret). Acceptance webhook action coverage updated accordingly.
 - **Secret Smoke**: validate `CURSOR_API_KEY` via Cloud Agents `GET /v1/me` instead of the Bugbot admin API; Bugbot disable is best-effort so non-team accounts no longer open a false secret-health issue.
 
 ### Added

--- a/docs/resources/git_stack.md
+++ b/docs/resources/git_stack.md
@@ -54,7 +54,8 @@ Set `context_dir` to widen Dockhand's compose working directory (relative to the
 - `auto_update_enabled` (Boolean, default: `false`)
 - `auto_update_cron` (String, default: `0 3 * * *`)
 - `webhook_enabled` (Boolean, default: `false`)
-- `webhook_secret` (String, Sensitive)
+- `webhook_secret_auto_generate` (Boolean, default: `false`) When `true` with `webhook_enabled=true`, Dockhand auto-generates a webhook secret if `webhook_secret` is omitted. Current Dockhand requires a secret whenever the webhook is enabled.
+- `webhook_secret` (String, Sensitive) Required when `webhook_enabled=true` unless `webhook_secret_auto_generate=true`.
 - `deploy_now` (Boolean, default: `false`) One-shot: set `true` to deploy on apply; state resets to `false` after apply.
 - `build_on_deploy` (Boolean, default: `false`)
 - `repull_images` (Boolean, default: `false`)

--- a/internal/provider/resource_git_stack.go
+++ b/internal/provider/resource_git_stack.go
@@ -448,12 +448,15 @@ func buildGitStackPayload(plan gitStackModel, triggers gitStackDeployTriggers) (
 	if webhookEnabled {
 		if !plan.WebhookSecret.IsNull() && !plan.WebhookSecret.IsUnknown() {
 			secret := strings.TrimSpace(plan.WebhookSecret.ValueString())
+			if secret == "" {
+				return gitStackPayload{}, fmt.Errorf("webhook_secret cannot be empty when webhook_enabled=true; set a secret or webhook_secret_auto_generate=true")
+			}
 			payload.WebhookSecret = &secret
 		} else if !webhookSecretAutoGenerate {
-			// Explicitly send empty secret when webhook is enabled and auto-generation is disabled.
-			empty := ""
-			payload.WebhookSecret = &empty
+			// Dockhand rejects webhook_enabled without a secret; do not send "".
+			return gitStackPayload{}, fmt.Errorf("webhook_enabled=true requires webhook_secret or webhook_secret_auto_generate=true")
 		}
+		// auto-generate: omit webhookSecret so Dockhand creates one
 	}
 
 	envVars, err := parseGitStackEnvVarsJSON(plan.EnvVarsJSON)

--- a/internal/provider/resource_git_stack_test.go
+++ b/internal/provider/resource_git_stack_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -135,7 +136,7 @@ func TestMergeGitStackStatePreservesContextDirWhenRemoteOmitsIt(t *testing.T) {
 	}
 }
 
-func TestBuildGitStackPayloadWebhookDisabledAutoGenerateSendsEmptySecret(t *testing.T) {
+func TestBuildGitStackPayloadWebhookRequiresSecretOrAutoGenerate(t *testing.T) {
 	plan := gitStackModel{
 		StackName:                 types.StringValue("test-stack"),
 		ComposePath:               types.StringValue("docker-compose.yml"),
@@ -150,12 +151,12 @@ func TestBuildGitStackPayloadWebhookDisabledAutoGenerateSendsEmptySecret(t *test
 		Branch:                    types.StringValue("main"),
 	}
 
-	payload, err := buildGitStackPayload(plan, gitStackDeployTriggers{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	_, err := buildGitStackPayload(plan, gitStackDeployTriggers{})
+	if err == nil {
+		t.Fatal("expected error when webhook is enabled without secret or auto-generate")
 	}
-	if payload.WebhookSecret == nil || *payload.WebhookSecret != "" {
-		t.Fatalf("expected empty webhook secret payload when auto-generate is disabled")
+	if !strings.Contains(err.Error(), "webhook_secret") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/provider/resource_schedule_webhook_contract_tf_acc_test.go
+++ b/internal/provider/resource_schedule_webhook_contract_tf_acc_test.go
@@ -150,13 +150,14 @@ func testAccGitStackWebhookActionConfig(env string, stackName string, repoURL st
 provider "dockhand" {}
 
 resource "dockhand_git_stack" "test" {
-  env             = %q
-  stack_name      = %q
-  url             = %q
-  branch          = %q
-  compose_path    = %q
-  deploy_now      = true
-  webhook_enabled = true%s
+  env                           = %q
+  stack_name                    = %q
+  url                           = %q
+  branch                        = %q
+  compose_path                  = %q
+  deploy_now                    = true
+  webhook_enabled               = true
+  webhook_secret_auto_generate  = true%s
 }
 
 resource "dockhand_git_stack_webhook_action" "test" {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `dockhand_git_stack` now errors clearly when `webhook_enabled=true` without `webhook_secret` or `webhook_secret_auto_generate=true` (Dockhand returns 400 for empty secrets).
- Acceptance `TestAccGitStackWebhookActionTerraform` sets `webhook_secret_auto_generate = true`.
- Docs list `webhook_secret_auto_generate` and the new requirement.

## Linked Issue

Related to automation tracker #240 (Acceptance Full / Release Watch failing on webhook create). That issue is `no-agent` and should auto-close when Acceptance Full is green again.

## What was fixed

- **Problem:** Nightly Acceptance Full and Dockhand Release Watch failed on `TestAccGitStackWebhookActionTerraform`.
- **Cause:** Newer Dockhand requires a webhook secret whenever the webhook is enabled; the test/provider previously allowed/sent an empty secret.
- **Change:** Provider-side validation + acceptance config + docs/CHANGELOG.

## User impact

- **Who:** Anyone enabling `webhook_enabled` on `dockhand_git_stack` without a secret
- **Action required:** set `webhook_secret` or `webhook_secret_auto_generate = true`
- **Workaround until release:** same as above on current builds if already hitting 400 from Dockhand

## Validation

- [x] `go test ./internal/provider/ -run TestBuildGitStackPayloadWebhook`
- [x] `./scripts/verify.sh --quality`
- [ ] Acceptance Full / Release Watch green after merge (closes #240 path)

## Release Notes

- [x] User-facing behavior changed (clearer validation when enabling webhooks without a secret)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e58d934-56ad-42da-a289-5eef0afb83ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e58d934-56ad-42da-a289-5eef0afb83ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

