### PR TITLE
fix(provider): generate webhook secret for Dockhand API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `dockhand_git_stack`: when `webhook_enabled=true`, require `webhook_secret` or `webhook_secret_auto_generate=true` (Dockhand rejects an empty secret). Acceptance webhook action coverage updated accordingly.
+- `dockhand_git_stack`: when `webhook_enabled=true`, require `webhook_secret` or `webhook_secret_auto_generate=true`. Auto-generate now creates a provider-side secret and sends it (Dockhand no longer accepts omitting the secret). Acceptance webhook coverage updated.
 - **Secret Smoke**: validate `CURSOR_API_KEY` via Cloud Agents `GET /v1/me` instead of the Bugbot admin API; Bugbot disable is best-effort so non-team accounts no longer open a false secret-health issue.
 
 ### Added

--- a/docs/resources/git_stack.md
+++ b/docs/resources/git_stack.md
@@ -54,7 +54,7 @@ Set `context_dir` to widen Dockhand's compose working directory (relative to the
 - `auto_update_enabled` (Boolean, default: `false`)
 - `auto_update_cron` (String, default: `0 3 * * *`)
 - `webhook_enabled` (Boolean, default: `false`)
-- `webhook_secret_auto_generate` (Boolean, default: `false`) When `true` with `webhook_enabled=true`, Dockhand auto-generates a webhook secret if `webhook_secret` is omitted. Current Dockhand requires a secret whenever the webhook is enabled.
+- `webhook_secret_auto_generate` (Boolean, default: `false`) When `true` with `webhook_enabled=true` and no `webhook_secret`, the provider generates a random secret and sends it to Dockhand (Dockhand requires a secret whenever webhooks are enabled).
 - `webhook_secret` (String, Sensitive) Required when `webhook_enabled=true` unless `webhook_secret_auto_generate=true`.
 - `deploy_now` (Boolean, default: `false`) One-shot: set `true` to deploy on apply; state resets to `false` after apply.
 - `build_on_deploy` (Boolean, default: `false`)

--- a/internal/provider/resource_git_stack.go
+++ b/internal/provider/resource_git_stack.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -155,15 +157,16 @@ func (r *gitStackResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Default:  booldefault.StaticBool(false),
 			},
 			"webhook_secret_auto_generate": schema.BoolAttribute{
-				MarkdownDescription: "When `true` and `webhook_enabled=true`, allow Dockhand to auto-generate a webhook secret if `webhook_secret` is not provided.",
+				MarkdownDescription: "When `true` and `webhook_enabled=true` without `webhook_secret`, the provider generates a random secret and sends it to Dockhand (required by current Dockhand when webhooks are enabled).",
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
 			},
 			"webhook_secret": schema.StringAttribute{
-				Optional:  true,
-				Computed:  true,
-				Sensitive: true,
+				MarkdownDescription: "Webhook HMAC secret. Required when `webhook_enabled=true` unless `webhook_secret_auto_generate=true`.",
+				Optional:            true,
+				Computed:            true,
+				Sensitive:           true,
 			},
 			"deploy_now": schema.BoolAttribute{
 				MarkdownDescription: "Request immediate deployment when set to `true`. Only sent to the API when transitioning to `true` (create or after changing from `false`). For ad-hoc redeploys prefer `dockhand_git_stack_deploy_action`.",
@@ -239,6 +242,11 @@ func (r *gitStackResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
+	if err := prepareGitStackWebhookSecret(&plan, nil); err != nil {
+		resp.Diagnostics.AddError("Invalid git stack configuration", err.Error())
+		return
+	}
+
 	payload, err := buildGitStackPayload(plan, gitStackDeployTriggersFrom(plan, gitStackModel{}, true))
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid git stack configuration", err.Error())
@@ -305,6 +313,11 @@ func (r *gitStackResource) Update(ctx context.Context, req resource.UpdateReques
 	env, err := r.client.requireResolvedEnv(firstKnownString(plan.Env, state.Env))
 	if err != nil {
 		resp.Diagnostics.AddError("Missing environment", err.Error())
+		return
+	}
+
+	if err := prepareGitStackWebhookSecret(&plan, &state); err != nil {
+		resp.Diagnostics.AddError("Invalid git stack configuration", err.Error())
 		return
 	}
 
@@ -375,6 +388,57 @@ func (r *gitStackResource) ImportState(ctx context.Context, req resource.ImportS
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
+func generateWebhookSecret() (string, error) {
+	buf := make([]byte, 24)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate webhook secret: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// prepareGitStackWebhookSecret ensures plan has a non-empty webhook_secret when
+// webhooks are enabled. Current Dockhand rejects webhookEnabled without a secret;
+// webhook_secret_auto_generate causes the provider to generate (or reuse state) one.
+func prepareGitStackWebhookSecret(plan *gitStackModel, state *gitStackModel) error {
+	webhookEnabled := false
+	if !plan.WebhookEnabled.IsNull() && !plan.WebhookEnabled.IsUnknown() {
+		webhookEnabled = plan.WebhookEnabled.ValueBool()
+	}
+	if !webhookEnabled {
+		return nil
+	}
+
+	if !plan.WebhookSecret.IsNull() && !plan.WebhookSecret.IsUnknown() {
+		if strings.TrimSpace(plan.WebhookSecret.ValueString()) == "" {
+			return fmt.Errorf("webhook_secret cannot be empty when webhook_enabled=true; set a secret or webhook_secret_auto_generate=true")
+		}
+		return nil
+	}
+
+	autoGenerate := false
+	if !plan.WebhookSecretAutoGenerate.IsNull() && !plan.WebhookSecretAutoGenerate.IsUnknown() {
+		autoGenerate = plan.WebhookSecretAutoGenerate.ValueBool()
+	}
+	if !autoGenerate {
+		return fmt.Errorf("webhook_enabled=true requires webhook_secret or webhook_secret_auto_generate=true")
+	}
+
+	if state != nil && !state.WebhookSecret.IsNull() && !state.WebhookSecret.IsUnknown() {
+		existing := strings.TrimSpace(state.WebhookSecret.ValueString())
+		if existing != "" {
+			plan.WebhookSecret = types.StringValue(existing)
+			return nil
+		}
+	}
+
+	secret, err := generateWebhookSecret()
+	if err != nil {
+		return err
+	}
+	plan.WebhookSecret = types.StringValue(secret)
+	return nil
+}
+
 func buildGitStackPayload(plan gitStackModel, triggers gitStackDeployTriggers) (gitStackPayload, error) {
 	stackName := strings.TrimSpace(plan.StackName.ValueString())
 	if stackName == "" {
@@ -401,11 +465,6 @@ func buildGitStackPayload(plan gitStackModel, triggers gitStackDeployTriggers) (
 	webhookEnabled := false
 	if !plan.WebhookEnabled.IsNull() && !plan.WebhookEnabled.IsUnknown() {
 		webhookEnabled = plan.WebhookEnabled.ValueBool()
-	}
-
-	webhookSecretAutoGenerate := false
-	if !plan.WebhookSecretAutoGenerate.IsNull() && !plan.WebhookSecretAutoGenerate.IsUnknown() {
-		webhookSecretAutoGenerate = plan.WebhookSecretAutoGenerate.ValueBool()
 	}
 
 	buildOnDeploy := false
@@ -446,17 +505,14 @@ func buildGitStackPayload(plan gitStackModel, triggers gitStackDeployTriggers) (
 	}
 
 	if webhookEnabled {
-		if !plan.WebhookSecret.IsNull() && !plan.WebhookSecret.IsUnknown() {
-			secret := strings.TrimSpace(plan.WebhookSecret.ValueString())
-			if secret == "" {
-				return gitStackPayload{}, fmt.Errorf("webhook_secret cannot be empty when webhook_enabled=true; set a secret or webhook_secret_auto_generate=true")
-			}
-			payload.WebhookSecret = &secret
-		} else if !webhookSecretAutoGenerate {
-			// Dockhand rejects webhook_enabled without a secret; do not send "".
+		if plan.WebhookSecret.IsNull() || plan.WebhookSecret.IsUnknown() {
 			return gitStackPayload{}, fmt.Errorf("webhook_enabled=true requires webhook_secret or webhook_secret_auto_generate=true")
 		}
-		// auto-generate: omit webhookSecret so Dockhand creates one
+		secret := strings.TrimSpace(plan.WebhookSecret.ValueString())
+		if secret == "" {
+			return gitStackPayload{}, fmt.Errorf("webhook_secret cannot be empty when webhook_enabled=true; set a secret or webhook_secret_auto_generate=true")
+		}
+		payload.WebhookSecret = &secret
 	}
 
 	envVars, err := parseGitStackEnvVarsJSON(plan.EnvVarsJSON)

--- a/internal/provider/resource_git_stack_test.go
+++ b/internal/provider/resource_git_stack_test.go
@@ -160,27 +160,52 @@ func TestBuildGitStackPayloadWebhookRequiresSecretOrAutoGenerate(t *testing.T) {
 	}
 }
 
-func TestBuildGitStackPayloadWebhookAllowsAutoGenerate(t *testing.T) {
+func TestPrepareGitStackWebhookSecretAutoGenerates(t *testing.T) {
 	plan := gitStackModel{
+		WebhookEnabled:            types.BoolValue(true),
+		WebhookSecretAutoGenerate: types.BoolValue(true),
+		WebhookSecret:             types.StringNull(),
+	}
+	if err := prepareGitStackWebhookSecret(&plan, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plan.WebhookSecret.IsNull() || strings.TrimSpace(plan.WebhookSecret.ValueString()) == "" {
+		t.Fatal("expected auto-generate to populate webhook_secret on plan")
+	}
+
+	payload, err := buildGitStackPayload(gitStackModel{
 		StackName:                 types.StringValue("test-stack"),
 		ComposePath:               types.StringValue("docker-compose.yml"),
 		WebhookEnabled:            types.BoolValue(true),
 		WebhookSecretAutoGenerate: types.BoolValue(true),
-		WebhookSecret:             types.StringNull(),
+		WebhookSecret:             plan.WebhookSecret,
 		AutoUpdateEnabled:         types.BoolValue(false),
 		AutoUpdateCron:            types.StringValue("0 3 * * *"),
 		DeployNow:                 types.BoolValue(false),
 		EnvVarsJSON:               types.StringValue("[]"),
 		URL:                       types.StringValue("https://example.com/repo.git"),
 		Branch:                    types.StringValue("main"),
-	}
-
-	payload, err := buildGitStackPayload(plan, gitStackDeployTriggers{})
+	}, gitStackDeployTriggers{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if payload.WebhookSecret != nil {
-		t.Fatalf("expected webhook secret to remain nil when auto-generate is enabled")
+	if payload.WebhookSecret == nil || *payload.WebhookSecret == "" {
+		t.Fatal("expected generated webhook secret to be sent in payload")
+	}
+}
+
+func TestPrepareGitStackWebhookSecretReusesState(t *testing.T) {
+	plan := gitStackModel{
+		WebhookEnabled:            types.BoolValue(true),
+		WebhookSecretAutoGenerate: types.BoolValue(true),
+		WebhookSecret:             types.StringNull(),
+	}
+	state := gitStackModel{WebhookSecret: types.StringValue("existing-secret")}
+	if err := prepareGitStackWebhookSecret(&plan, &state); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plan.WebhookSecret.ValueString() != "existing-secret" {
+		t.Fatalf("expected state secret reuse, got %q", plan.WebhookSecret.ValueString())
 	}
 }
 

--- a/internal/provider/resource_schedule_webhook_contract_tf_acc_test.go
+++ b/internal/provider/resource_schedule_webhook_contract_tf_acc_test.go
@@ -150,14 +150,15 @@ func testAccGitStackWebhookActionConfig(env string, stackName string, repoURL st
 provider "dockhand" {}
 
 resource "dockhand_git_stack" "test" {
-  env                           = %q
-  stack_name                    = %q
-  url                           = %q
-  branch                        = %q
-  compose_path                  = %q
-  deploy_now                    = true
-  webhook_enabled               = true
-  webhook_secret_auto_generate  = true%s
+  env                          = %q
+  stack_name                   = %q
+  url                          = %q
+  branch                       = %q
+  compose_path                 = %q
+  deploy_now                   = true
+  webhook_enabled              = true
+  webhook_secret               = "tf-acc-webhook-secret"
+  webhook_secret_auto_generate = true%s
 }
 
 resource "dockhand_git_stack_webhook_action" "test" {


### PR DESCRIPTION
## Summary
- `webhook_secret_auto_generate=true` now generates a provider-side secret and sends it (Dockhand rejects omitting `webhookSecret`).
- Acceptance webhook test sets an explicit `webhook_secret`.
- Follow-up to #241 — auto-generate-by-omit was insufficient.

## What was fixed
- **Problem:** Acceptance Full / Release Watch still failed with `A webhook secret is required when the webhook is enabled` after #241.
- **Cause:** Current Dockhand does not auto-create a secret when the field is omitted.
- **Change:** Provider generates/reuses a secret before create/update; tests send an explicit secret.

## User impact
- **Who:** Users of `webhook_secret_auto_generate`
- **Action required:** none if already using auto-generate; upgrade picks up working behavior
- **Workaround until release:** set `webhook_secret` explicitly

## Validation
- [x] `./scripts/verify.sh --quality`
- [ ] Acceptance Full / Release Watch after merge