### PR TITLE
fix(provider): sign git stack webhook action requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `dockhand_git_stack`: when `webhook_enabled=true`, require `webhook_secret` or `webhook_secret_auto_generate=true`. Auto-generate now creates a provider-side secret and sends it (Dockhand no longer accepts omitting the secret). Acceptance webhook coverage updated.
+- `dockhand_git_stack`: when `webhook_enabled=true`, require `webhook_secret` or `webhook_secret_auto_generate=true`. Auto-generate now creates a provider-side secret and sends it (Dockhand no longer accepts omitting the secret).
+- `dockhand_git_stack_webhook_action`: accept `webhook_secret` and sign webhook requests (`X-Hub-Signature-256` / `X-Gitlab-Token` / `?secret=`) so triggers succeed against current Dockhand.
 - **Secret Smoke**: validate `CURSOR_API_KEY` via Cloud Agents `GET /v1/me` instead of the Bugbot admin API; Bugbot disable is best-effort so non-team accounts no longer open a false secret-health issue.
 
 ### Added

--- a/docs/resources/git_stack_webhook_action.md
+++ b/docs/resources/git_stack_webhook_action.md
@@ -6,8 +6,9 @@ Triggers a one-shot webhook run for a Dockhand git stack.
 
 ```terraform
 resource "dockhand_git_stack_webhook_action" "sync_stack" {
-  stack_id = "12"
-  trigger  = "2026-02-12T22:00:00Z"
+  stack_id       = dockhand_git_stack.example.id
+  webhook_secret = dockhand_git_stack.example.webhook_secret
+  trigger        = "2026-02-12T22:00:00Z"
 }
 ```
 
@@ -19,6 +20,7 @@ resource "dockhand_git_stack_webhook_action" "sync_stack" {
 
 ### Optional
 
+- `webhook_secret` (String, Sensitive) Webhook secret from the git stack. Required by current Dockhand when the stack webhook is enabled (request is signed with `X-Hub-Signature-256` / `X-Gitlab-Token` and `?secret=`).
 - `trigger` (String) Arbitrary value; change it to re-run.
 
 ### Read-Only

--- a/examples/resources/dockhand_git_stack_webhook_action/resource.tf
+++ b/examples/resources/dockhand_git_stack_webhook_action/resource.tf
@@ -1,4 +1,5 @@
 resource "dockhand_git_stack_webhook_action" "example" {
-  stack_id = "12"
-  trigger  = "2026-02-12T22:00:00Z"
+  stack_id       = "12"
+  webhook_secret = "replace-with-stack-webhook-secret"
+  trigger        = "2026-02-12T22:00:00Z"
 }

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -120,10 +120,14 @@ func (c *Client) Health(ctx context.Context, env string) (*healthResponse, error
 }
 
 func (c *Client) doJSONWithStatus(ctx context.Context, method string, path string, query map[string]string, in any, out any) (int, error) {
-	return c.doJSONWithStatusUsingClient(ctx, c.httpClient, method, path, query, in, out)
+	return c.doJSONWithStatusUsingClient(ctx, c.httpClient, method, path, query, nil, in, out)
 }
 
-func (c *Client) doJSONWithStatusUsingClient(ctx context.Context, httpClient *http.Client, method string, path string, query map[string]string, in any, out any) (int, error) {
+func (c *Client) doJSONWithStatusHeaders(ctx context.Context, method string, path string, query map[string]string, headers map[string]string, in any, out any) (int, error) {
+	return c.doJSONWithStatusUsingClient(ctx, c.httpClient, method, path, query, headers, in, out)
+}
+
+func (c *Client) doJSONWithStatusUsingClient(ctx context.Context, httpClient *http.Client, method string, path string, query map[string]string, headers map[string]string, in any, out any) (int, error) {
 	var payloadBytes []byte
 	if in != nil {
 		data, err := json.Marshal(in)
@@ -167,6 +171,12 @@ func (c *Client) doJSONWithStatusUsingClient(ctx context.Context, httpClient *ht
 		req.Header.Set("Accept", "application/json")
 		if payloadBytes != nil {
 			req.Header.Set("Content-Type", "application/json")
+		}
+		for key, value := range headers {
+			if strings.TrimSpace(key) == "" || strings.TrimSpace(value) == "" {
+				continue
+			}
+			req.Header.Set(key, value)
 		}
 		c.applyAuthHeaders(req)
 

--- a/internal/provider/client_git.go
+++ b/internal/provider/client_git.go
@@ -2,6 +2,10 @@ package provider
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -177,8 +181,26 @@ func (c *Client) DeleteGitStack(ctx context.Context, env string, id string) (int
 	return c.doJSONWithStatus(ctx, http.MethodDelete, "/api/git/stacks/"+url.PathEscape(id), query, nil, nil)
 }
 
-func (c *Client) TriggerGitStackWebhook(ctx context.Context, id string) (int, error) {
-	return c.doJSONWithStatus(ctx, http.MethodPost, "/api/git/stacks/"+url.PathEscape(id)+"/webhook", nil, map[string]any{}, nil)
+func (c *Client) TriggerGitStackWebhook(ctx context.Context, id string, secret string) (int, error) {
+	body := map[string]any{}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return 0, err
+	}
+
+	query := map[string]string{}
+	headers := map[string]string{}
+	secret = strings.TrimSpace(secret)
+	if secret != "" {
+		query["secret"] = secret
+		headers["X-Gitlab-Token"] = secret
+		mac := hmac.New(sha256.New, []byte(secret))
+		_, _ = mac.Write(payload)
+		headers["X-Hub-Signature-256"] = "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	}
+
+	// json.RawMessage keeps HMAC bytes identical to the request body Dockhand verifies.
+	return c.doJSONWithStatusHeaders(ctx, http.MethodPost, "/api/git/stacks/"+url.PathEscape(id)+"/webhook", query, headers, json.RawMessage(payload), nil)
 }
 
 func (c *Client) ListGitStackEnvFiles(ctx context.Context, id string) ([]string, int, error) {

--- a/internal/provider/client_image.go
+++ b/internal/provider/client_image.go
@@ -135,7 +135,7 @@ func (c *Client) PushImage(ctx context.Context, env string, imageID string, regi
 		RegistryID: registryID,
 	}
 	pushClient := c.httpClientWithTimeout(5 * time.Minute)
-	return c.doJSONWithStatusUsingClient(ctx, pushClient, http.MethodPost, "/api/images/push", query, payload, nil)
+	return c.doJSONWithStatusUsingClient(ctx, pushClient, http.MethodPost, "/api/images/push", query, nil, payload, nil)
 }
 
 func (c *Client) ScanImage(ctx context.Context, env string, imageName string) (string, int, error) {
@@ -147,7 +147,7 @@ func (c *Client) ScanImage(ctx context.Context, env string, imageName string) (s
 	scanClient := *c.httpClient
 	scanClient.Timeout = 3 * time.Minute
 
-	status, err := c.doJSONWithStatusUsingClient(ctx, &scanClient, http.MethodPost, "/api/images/scan", query, imageScanPayload{ImageName: imageName}, nil)
+	status, err := c.doJSONWithStatusUsingClient(ctx, &scanClient, http.MethodPost, "/api/images/scan", query, nil, imageScanPayload{ImageName: imageName}, nil)
 	if err != nil {
 		return "", status, err
 	}

--- a/internal/provider/resource_git_stack_webhook_action.go
+++ b/internal/provider/resource_git_stack_webhook_action.go
@@ -28,9 +28,10 @@ type gitStackWebhookActionResource struct {
 }
 
 type gitStackWebhookActionModel struct {
-	ID      types.String `tfsdk:"id"`
-	StackID types.String `tfsdk:"stack_id"`
-	Trigger types.String `tfsdk:"trigger"`
+	ID            types.String `tfsdk:"id"`
+	StackID       types.String `tfsdk:"stack_id"`
+	WebhookSecret types.String `tfsdk:"webhook_secret"`
+	Trigger       types.String `tfsdk:"trigger"`
 }
 
 func (r *gitStackWebhookActionResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -39,7 +40,7 @@ func (r *gitStackWebhookActionResource) Metadata(_ context.Context, req resource
 
 func (r *gitStackWebhookActionResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Triggers a one-shot git stack webhook call via `/api/git/stacks/{id}/webhook`. Change `trigger` to run again.",
+		MarkdownDescription: "Triggers a one-shot git stack webhook call via `/api/git/stacks/{id}/webhook`. Change `trigger` to run again. Current Dockhand requires a valid webhook secret/signature when the stack webhook is enabled.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -47,6 +48,14 @@ func (r *gitStackWebhookActionResource) Schema(_ context.Context, _ resource.Sch
 			"stack_id": schema.StringAttribute{
 				MarkdownDescription: "Git stack numeric ID.",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"webhook_secret": schema.StringAttribute{
+				MarkdownDescription: "Webhook secret configured on the git stack. Used to sign the request (`X-Hub-Signature-256` / `X-Gitlab-Token` / `?secret=`).",
+				Optional:            true,
+				Sensitive:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -91,7 +100,12 @@ func (r *gitStackWebhookActionResource) Create(ctx context.Context, req resource
 		return
 	}
 
-	status, err := r.client.TriggerGitStackWebhook(ctx, stackID)
+	secret := ""
+	if !plan.WebhookSecret.IsNull() && !plan.WebhookSecret.IsUnknown() {
+		secret = strings.TrimSpace(plan.WebhookSecret.ValueString())
+	}
+
+	status, err := r.client.TriggerGitStackWebhook(ctx, stackID, secret)
 	if err != nil {
 		resp.Diagnostics.AddError("Error triggering git stack webhook", err.Error())
 		return

--- a/internal/provider/resource_schedule_webhook_contract_tf_acc_test.go
+++ b/internal/provider/resource_schedule_webhook_contract_tf_acc_test.go
@@ -162,8 +162,9 @@ resource "dockhand_git_stack" "test" {
 }
 
 resource "dockhand_git_stack_webhook_action" "test" {
-  stack_id = dockhand_git_stack.test.id
-  trigger  = %q
+  stack_id       = dockhand_git_stack.test.id
+  webhook_secret = dockhand_git_stack.test.webhook_secret
+  trigger        = %q
 }
 `, env, stackName, repoURL, branch, composePath, credentialBlock, trigger)
 }


### PR DESCRIPTION
## Summary
- `dockhand_git_stack_webhook_action` takes optional `webhook_secret` and signs the trigger request for current Dockhand.
- Acceptance passes the stack secret into the action.

## What was fixed
- **Problem:** After webhook create was fixed, Acceptance still failed with `401 Invalid webhook signature` on the webhook action.
- **Cause:** Dockhand now verifies webhook signatures when a secret is configured; the action posted an unsigned body.
- **Change:** Sign with HMAC-SHA256 + GitLab token + query secret.

## Validation
- [x] `./scripts/verify.sh --quality`
- [ ] Acceptance Full / Release Watch after merge