### PR TITLE
fix(ci): allowlist registry tag-info API drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `dockhand_git_stack`: when `webhook_enabled=true`, require `webhook_secret` or `webhook_secret_auto_generate=true`. Auto-generate now creates a provider-side secret and sends it (Dockhand no longer accepts omitting the secret).
 - `dockhand_git_stack_webhook_action`: accept `webhook_secret` and sign webhook requests (`X-Hub-Signature-256` / `X-Gitlab-Token` / `?secret=`) so triggers succeed against current Dockhand.
+- Allowlist `/api/registry/tag-info` in `docs/non-present-endpoints.md` so Acceptance Full API drift gate passes while provider coverage is tracked (#244).
 - **Secret Smoke**: validate `CURSOR_API_KEY` via Cloud Agents `GET /v1/me` instead of the Bugbot admin API; Bugbot disable is best-effort so non-team accounts no longer open a false secret-health issue.
 
 ### Added

--- a/docs/non-present-endpoints.md
+++ b/docs/non-present-endpoints.md
@@ -13,7 +13,12 @@ This file tracks API endpoints that are not currently available on the tested Do
 - `GET /api/configs`
 - `GET /api/backups`
 
+## Present but not yet in provider/probe surface
+
+- `/api/registry/tag-info` — discovered on Dockhand `latest` (2026-08-02); track for future registry tag metadata coverage (issue #244).
+
 ## Notes
 
 - These are documented as backlog candidates only; no provider resources/data sources should depend on them until the API is present and stable.
 - Compatibility reports refresh via **Compat Reports Sync** on green Acceptance Full / Release Watch runs.
+- Paths listed above also serve as the API drift allowlist consumed by `scripts/api-drift-gate.py`.


### PR DESCRIPTION
## Summary
- Allowlist `/api/registry/tag-info` in `docs/non-present-endpoints.md` (API drift from Dockhand latest).
- Unblocks Acceptance Full after webhook fixes; tracks follow-up as #244.

## Linked Issue
Fixes #244

## What was fixed
- **Problem:** Acceptance Full harness passed but API drift gate failed on new `/api/registry/tag-info`.
- **Cause:** Dockhand `latest` added a route not in probe/provider surface.
- **Change:** Allowlist as backlog while provider coverage is planned.

## Validation
- [x] allowlist parse includes `/api/registry/tag-info`
- [ ] Acceptance Full green after merge