### PR TITLE
fix(agent): issue 244 api drift detected dockhand latest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,7 @@ Optional: download release zips into `./terraform/dockhand/mirror` for local Ter
   - `POST /api/images/scan`
   - `GET /api/registry/search`
   - `GET /api/registry/tags`
+  - `GET /api/registry/tag-info`
   - `GET /api/registry/catalog`
   - `DELETE /api/registry/image`
   - `GET/POST/DELETE /api/containers`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `dockhand_git_stack`: when `webhook_enabled=true`, require `webhook_secret` or `webhook_secret_auto_generate=true`. Auto-generate now creates a provider-side secret and sends it (Dockhand no longer accepts omitting the secret).
 - `dockhand_git_stack_webhook_action`: accept `webhook_secret` and sign webhook requests (`X-Hub-Signature-256` / `X-Gitlab-Token` / `?secret=`) so triggers succeed against current Dockhand.
 - **Secret Smoke**: validate `CURSOR_API_KEY` via Cloud Agents `GET /v1/me` instead of the Bugbot admin API; Bugbot disable is best-effort so non-team accounts no longer open a false secret-health issue.
+- Track `GET /api/registry/tag-info` in endpoint probe coverage so Acceptance Full API drift gate passes on Dockhand `latest` (#244).
 
 ### Added
 

--- a/docs/api-matrix.md
+++ b/docs/api-matrix.md
@@ -167,7 +167,7 @@ Live verification artifacts:
 | `/api/batch` + `/api/jobs/{jobId}` | generic async job action + job status data source (`run-and-poll`) | implemented |
 | `/api/environments/test` + `/api/environments/detect-socket` | environment connectivity validation action + socket discovery data source | implemented |
 | `/api/notifications/test` | notification test-send one-shot action | implemented |
-| `/api/registry/*` (`search`,`tags`,`catalog`,`image`) | registry catalog/search data sources + remote image delete action | implemented |
+| `/api/registry/*` (`search`,`tags`,`tag-info`,`catalog`,`image`) | registry catalog/search data sources + remote image delete action; `tag-info` tracked by probe only | partial |
 | `/api/prune/*` | explicit cleanup action resources | implemented |
 | `/api/system*` | system introspection/file-browser data sources | implemented |
 | `/api/configs` | config management resource/data source | planned (verified not present on tested instance; `404`) |

--- a/docs/reports/agent-review-log.md
+++ b/docs/reports/agent-review-log.md
@@ -973,3 +973,65 @@ Append-only record of lens sweeps. See `docs/AGENT_REVIEW_LENSES.md`.
 - **Blocking findings:** none
 - **Deferred medium/low:** probe fixture 404 tuning; backup API routes for future provider expansion; shrink `manifestOperationExemptions`; registry-and-image `timestamp()` example; README version pin bump; optional artifact scrubbing and auth error sanitization — carry forward from v0.1.85–v0.1.88 (no new high-severity regressions)
 
+---
+
+## Issue #244 — API drift detected: dockhand latest
+
+### 2026-08-02 — API compatibility
+
+**Scope:** `scripts/endpoint-probe.py`, `scripts/api-drift-gate.py`, `docs/api-matrix.md`, `docs/non-present-endpoints.md`, `docs/reports/docs-reference-api-endpoints.txt`, `docs/reports/api-drift-gate.md`, `internal/provider/client_registry.go`.
+
+**Summary:** Dockhand `latest` added `GET /api/registry/tag-info`, discovered by Acceptance Full compat sync (run 30753361374). Added probe entry with `image`, `tag`, and optional `registry` query fixtures matching existing registry probe patterns. Simulated drift gate (`newly_discovered=1`) passes with zero unallowlisted endpoints after probe update.
+
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| med | `docs/api-matrix.md:170` | `tag-info` tracked by probe only; no Terraform data source yet | Add `dockhand_registry_tag_info` data source in follow-up when response shape is documented |
+| low | `internal/provider/client_registry.go` | No client wrapper for `tag-info` | Optional client method when implementing data source (deferred) |
+| — | `scripts/endpoint-probe.py:78,470-474` | Probe tracks `GET /api/registry/tag-info` | Fixed (#244) |
+| — | `scripts/api-drift-gate.py` | Simulated new-endpoint gate passes (`new_relevant_unallowlisted=0`) | Fixed (#244) |
+| — | `docs/non-present-endpoints.md` | Backlog still limited to 404 routes (`configs`, `backups`) | Current |
+
+---
+
+### 2026-08-02 — Ops / SRE
+
+**Scope:** `.github/workflows/acceptance-ci.yml`, `.github/workflows/dockhand-release-watch.yml`, `.github/workflows/compat-reports-sync.yml`, `.github/workflows/agent-validate.yml`, `scripts/verify.sh`, `scripts/lens_sweep_gate.py`, CI run https://github.com/kalebharrison/terraform-provider-dockhand/actions/runs/30753361374.
+
+**Summary:** Drift failure originated from Compat Reports Sync comparing refreshed docs-reference endpoints against probe baseline. Fix is probe-only; no harness or workflow changes required. Agent Validate enforces lens log update via `lens_sweep_gate.py`.
+
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| med | `compat-reports-sync.yml` | Drift gate opens agent issues on new routes — working as designed | None; this issue is the expected remediation path |
+| low | `docs/reports/docs-reference-api-endpoints.txt` | Baseline will refresh post-merge via Compat Reports Sync | Automatic after green Acceptance Full |
+| — | `scripts/verify.sh` | Quality gate unchanged; probe list edit is Python-only | Current |
+| — | `scripts/lens_sweep_gate.py` | Requires agent-review-log update on agent branches | Satisfied by this sweep |
+
+---
+
+### 2026-08-02 — Acceptance & regression
+
+**Scope:** `internal/provider/testdata/acceptance_manifest.json`, `internal/provider/testdata/acceptance_pr_ci.json`, `internal/provider/resource_new_surfaces_tf_acc_test.go` (`TestAccRegistrySurfacesTerraform`), `scripts/endpoint-probe.py`, `internal/provider/*_tf_acc_test.go` (grep for registry coverage).
+
+**Summary:** No acceptance manifest or test changes required — probe coverage satisfies the drift gate without a new Terraform surface. Existing `TestAccRegistrySurfacesTerraform` exercises `dockhand_registry_tags`, `dockhand_registry_search`, and `dockhand_registry_catalog`; tag metadata via `tag-info` remains unmapped until a data source is added.
+
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| med | `acceptance_manifest.json` | No manifest row for future `dockhand_registry_tag_info` | Add when data source is implemented (deferred) |
+| low | `resource_new_surfaces_tf_acc_test.go` | Registry acceptance suite does not cover `tag-info` | Extend suite when client/data source lands (deferred) |
+| — | `scripts/endpoint-probe.py` | Probe fixture uses `library/busybox:latest` | Fixed (#244) |
+| — | `acceptance_pr_ci.json` | PR CI registry path unchanged | Current |
+
+---
+
+### 2026-08-02 — Senior developer
+
+**Scope:** `scripts/endpoint-probe.py` (probe list + fixture block), `internal/provider/client_registry.go`, `docs/api-matrix.md`, `AGENTS.md`, `CHANGELOG.md`.
+
+**Summary:** Minimal focused diff: one probe list entry, one fixture block mirroring adjacent registry routes, and doc/changelog updates. No Go code changes; client domain file unchanged. Probe fixture ordering follows existing `registry/tags` → `registry/catalog` pattern.
+
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| low | `scripts/endpoint-probe.py:470-474` | Tag-info fixture duplicates registry/image query shape | Acceptable; extract shared helper only if more registry probes accumulate (deferred) |
+| — | `scripts/endpoint-probe.py` | Entry inserted adjacent to related registry routes | Fixed (#244) |
+| — | `CHANGELOG.md` | Unreleased note documents probe coverage | Fixed (#244) |
+

--- a/scripts/endpoint-probe.py
+++ b/scripts/endpoint-probe.py
@@ -75,6 +75,7 @@ ENDPOINTS: List[Dict[str, Any]] = [
     {"method": "POST", "path": "/api/registries/test"},
     {"method": "GET", "path": "/api/registry/search"},
     {"method": "GET", "path": "/api/registry/tags"},
+    {"method": "GET", "path": "/api/registry/tag-info"},
     {"method": "GET", "path": "/api/registry/catalog"},
     {"method": "DELETE", "path": "/api/registry/image"},
     {"method": "GET", "path": "/api/git/credentials"},
@@ -467,6 +468,10 @@ def main() -> int:
                 query["registry"] = str(fixtures["registry_id"])
             query["page"] = "1"
             query["pageSize"] = "5"
+        if raw_path == "/api/registry/tag-info":
+            query = {"image": "library/busybox", "tag": "latest"}
+            if fixtures.get("registry_id"):
+                query["registry"] = str(fixtures["registry_id"])
         if raw_path == "/api/registry/catalog":
             query = {"page": "1", "pageSize": "5"}
             if fixtures.get("registry_id"):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #244

## Summary

- Add `GET /api/registry/tag-info` to endpoint probe coverage so Acceptance Full API drift gate passes on Dockhand `latest`.
- Document the route in `AGENTS.md`, `docs/api-matrix.md`, and `CHANGELOG.md`.
- Complete required lens sweep for issue #244 in `docs/reports/agent-review-log.md`.

## What was fixed

- **Problem:** Compat Reports Sync detected a new Dockhand route (`GET /api/registry/tag-info`) on `fnsys/dockhand:latest` that was not tracked by `scripts/endpoint-probe.py`, causing the API drift gate to fail (run 30753361374).
- **Cause:** Dockhand added tag metadata lookup for the registry browser; the provider probe list had not been updated.
- **Change:** Added probe entry with `image`, `tag`, and optional `registry` query fixtures (matching existing registry probe patterns). Updated API matrix/docs/changelog; appended Issue #244 lens review sections.

## User impact

- **Who:** Maintainers and CI (Acceptance Full / Release Watch compat sync). No Terraform provider behavior change for end users.
- **Action required:** None — merge and let CI refresh compat baselines.
- **Workaround until release:** N/A (CI-only fix).

## Validation

- `./scripts/verify.sh --quality`
- Simulated API drift gate with `tag-info` as newly discovered: `new_relevant_unallowlisted=0`
- Agent Validate: pending on push

## Release Notes

- [ ] User-facing behavior changed
- [x] No user-facing behavior change

## Surface Parity

- [ ] Updated docs page(s) for changed resource/data source
- [ ] Updated example file(s) for changed resource/data source
- [ ] Updated acceptance manifest mapping when adding/changing resource/data source

Probe-only coverage; no new Terraform resource or data source in this PR. A follow-up may add `dockhand_registry_tag_info` once the response contract is documented.

## Issue follow-up

After merge, **Agent Merge Cleanup** comments on linked issues. After release, **Agent Release Tag** adds the version. See `docs/AGENT_ISSUE_RESPONSE.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c78fa15-1ad1-4fbc-b4f1-04be9af4d680?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c78fa15-1ad1-4fbc-b4f1-04be9af4d680&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

### Automation

- Validate run: https://github.com/kalebharrison/terraform-provider-dockhand/actions/runs/30753773947
- Branch: `agent/issue-244-api-drift-detected-dockhand-latest`
- Head: `1fdec9dc4179e7c16816a4fa0a476b0a5122f6ab`

Opened by the Agent Open PR workflow.