### PR TITLE
chore(release): cut CHANGELOG for v0.1.89

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.89] - 2026-08-02
+
 ### Fixed
 
 - `dockhand_git_stack`: when `webhook_enabled=true`, require `webhook_secret` or `webhook_secret_auto_generate=true`. Auto-generate now creates a provider-side secret and sends it (Dockhand no longer accepts omitting the secret).


### PR DESCRIPTION
## Summary
- Move Unreleased notes under `[0.1.89]` after publishing https://github.com/kalebharrison/terraform-provider-dockhand/releases/tag/v0.1.89
- Direct push from release housekeeping is blocked by branch protection.

## Validation
- [x] v0.1.89 published
- [ ] Auto-merge when checks pass