### PR TITLE
fix(agent): issue 267 bug can t use a dockhand git repository with exi

### DIFF
--- a/docs/reports/agent-review-log.md
+++ b/docs/reports/agent-review-log.md
@@ -1161,3 +1161,30 @@ Append-only record of lens sweeps. See `docs/AGENT_REVIEW_LENSES.md`.
 - **Blocking findings:** none
 - **Deferred medium/low:** navigation settings Terraform resource; README version pin example — carried forward from v0.1.90, no new medium/low items
 
+## Issue #267 — [Bug]: Can't use a `dockhand_git_repository` with existing repo, but new branch
+
+### 2026-08-19 — Acceptance & regression
+
+**Scope:** `internal/provider/resource_git_stack.go`, `internal/provider/resource_git_stack_test.go`, `internal/provider/resource_git_stack_tf_acc_test.go`, `internal/provider/testdata/acceptance_manifest.json`, `internal/provider/testdata/acceptance_pr_ci.json`
+
+**Summary:** Root cause was a schema default (`branch = "main"`) on `dockhand_git_stack` that planned `main` even when only `repository_id` was set, then failed apply with inconsistent result when Dockhand returned the linked repository branch. Fix removes the default, adds unit tests for repository-id payload/state mapping, and adds `TestAccGitStackRepositoryIDInheritsBranchTerraform` acceptance coverage.
+
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| high | `resource_git_stack.go:120-124` | `branch` schema default `main` caused inconsistent result after apply when `repository_id` references a non-main branch | Fixed: remove default; branch computed from linked repo |
+| — | `resource_git_stack_test.go` | Added unit tests for repository-id branch inheritance and URL default | Fixed in this branch |
+| — | `resource_git_stack_tf_acc_test.go` | Added acceptance test for repository_id without explicit branch | Fixed in this branch |
+| low | `acceptance_pr_ci.json` | New acceptance test not in PR CI subset (runs on full acceptance only) | Defer — existing git stack destroy test remains in PR CI |
+
+### 2026-08-19 — Senior developer
+
+**Scope:** `internal/provider/resource_git_stack.go` (schema, `buildGitStackPayload`, `mergeGitStackState`, `modelFromGitStackResponse`), `docs/resources/git_stack.md`
+
+**Summary:** Bug was localized to Plugin Framework schema defaults conflicting with computed API-derived attributes. URL-based creation still defaults branch to `main` in payload builder; repository-id path correctly omits branch from POST body. No broader client or lookup-by-URL conflation found.
+
+| Severity | Location | Finding | Suggested action |
+|----------|----------|---------|------------------|
+| — | `resource_git_stack.go` | URL-mode branch default correctly handled in `buildGitStackPayload` | No action |
+| — | `mergeGitStackState` | Remote branch already wins when API returns nested repository | No action |
+| low | `resource_git_stack.go` | `url`/`repo_name`/`credential_id` also computed when using `repository_id`; same class of issue if defaults added later | Document only (done in git_stack.md) |
+

--- a/docs/resources/git_stack.md
+++ b/docs/resources/git_stack.md
@@ -47,7 +47,7 @@ Set `context_dir` to widen Dockhand's compose working directory (relative to the
 - `repository_id` (String)
 - `repo_name` (String)
 - `url` (String)
-- `branch` (String, default: `main`)
+- `branch` (String) Git branch when creating via `url` (defaults to `main` in the API payload). When `repository_id` is set, branch is computed from the linked repository.
 - `credential_id` (String)
 - `context_dir` (String) Repository-relative working directory for Docker Compose. Use `.` for the repo root when shared files live outside the compose file directory.
 - `env_file_path` (String)
@@ -64,6 +64,8 @@ Set `context_dir` to widen Dockhand's compose working directory (relative to the
 
 `repository_id` is preferred when you already manage the repository with `dockhand_git_repository`.
 If `repository_id` is not set, `url` must be set (and optional `repo_name`, `branch`, `credential_id`).
+
+When using `repository_id`, omit `branch`/`url`/`repo_name` — they are populated from the linked repository after apply. Multiple `dockhand_git_repository` resources may share the same clone URL with different branches.
 
 ### Read-Only
 

--- a/internal/provider/resource_git_stack.go
+++ b/internal/provider/resource_git_stack.go
@@ -118,9 +118,12 @@ func (r *gitStackResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Computed: true,
 			},
 			"branch": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-				Default:  stringdefault.StaticString("main"),
+				MarkdownDescription: "Git branch when creating via `url`. When `repository_id` is set, branch is read from the linked repository. Defaults to `main` only for URL-based creation.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"credential_id": schema.StringAttribute{
 				Optional: true,

--- a/internal/provider/resource_git_stack_test.go
+++ b/internal/provider/resource_git_stack_test.go
@@ -38,6 +38,96 @@ func (f *fakeGitStackDestroyClient) DeleteGitStack(_ context.Context, env string
 	return f.deleteGitStackStatus, f.deleteGitStackErr
 }
 
+func TestModelFromGitStackResponseMapsRepositoryBranchToBranch(t *testing.T) {
+	branch := "feature/observability"
+	resp := &gitStackResponse{
+		ID:         1,
+		StackName:  "observability",
+		AutoUpdate: false,
+		Repository: &gitStackRepositoryResponse{
+			Name:   "stacks_observability",
+			URL:    "ssh://git@example.com/stacks.git",
+			Branch: &branch,
+		},
+	}
+
+	model := modelFromGitStackResponse(resp)
+	if model.Branch.IsNull() || model.Branch.ValueString() != branch {
+		t.Fatalf("expected branch %q from linked repository, got null=%v value=%q", branch, model.Branch.IsNull(), model.Branch.ValueString())
+	}
+	if model.RepositoryBranch.IsNull() || model.RepositoryBranch.ValueString() != branch {
+		t.Fatalf("expected repository_branch %q, got null=%v value=%q", branch, model.RepositoryBranch.IsNull(), model.RepositoryBranch.ValueString())
+	}
+}
+
+func TestMergeGitStackStateRepositoryIDUsesRemoteBranch(t *testing.T) {
+	preferred := gitStackModel{
+		RepositoryID: types.StringValue("2"),
+		Branch:       types.StringNull(),
+	}
+	remote := gitStackModel{
+		RepositoryID: types.StringValue("2"),
+		Branch:       types.StringValue("feature/observability"),
+	}
+
+	merged := mergeGitStackState(preferred, remote)
+	if merged.Branch.IsNull() || merged.Branch.ValueString() != "feature/observability" {
+		t.Fatalf("expected linked repository branch in state, got null=%v value=%q", merged.Branch.IsNull(), merged.Branch.ValueString())
+	}
+}
+
+func TestBuildGitStackPayloadRepositoryIDOmitsBranch(t *testing.T) {
+	repoID := int64(2)
+	plan := gitStackModel{
+		StackName:                 types.StringValue("observability"),
+		ComposePath:               types.StringValue("stacks/observability/compose.yml"),
+		RepositoryID:              types.StringValue("2"),
+		Branch:                    types.StringNull(),
+		WebhookEnabled:            types.BoolValue(false),
+		WebhookSecretAutoGenerate: types.BoolValue(false),
+		WebhookSecret:             types.StringNull(),
+		AutoUpdateEnabled:         types.BoolValue(false),
+		AutoUpdateCron:            types.StringValue("0 3 * * *"),
+		DeployNow:                 types.BoolValue(false),
+		EnvVarsJSON:               types.StringValue("[]"),
+	}
+
+	payload, err := buildGitStackPayload(plan, gitStackDeployTriggers{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if payload.RepositoryID == nil || *payload.RepositoryID != repoID {
+		t.Fatalf("expected repository_id 2 in payload, got %#v", payload.RepositoryID)
+	}
+	if payload.Branch != nil {
+		t.Fatalf("expected branch omitted when repository_id is set, got %#v", payload.Branch)
+	}
+}
+
+func TestBuildGitStackPayloadURLDefaultsBranchToMain(t *testing.T) {
+	plan := gitStackModel{
+		StackName:                 types.StringValue("test-stack"),
+		ComposePath:               types.StringValue("docker-compose.yml"),
+		URL:                       types.StringValue("https://example.com/repo.git"),
+		Branch:                    types.StringNull(),
+		WebhookEnabled:            types.BoolValue(false),
+		WebhookSecretAutoGenerate: types.BoolValue(false),
+		WebhookSecret:             types.StringNull(),
+		AutoUpdateEnabled:         types.BoolValue(false),
+		AutoUpdateCron:            types.StringValue("0 3 * * *"),
+		DeployNow:                 types.BoolValue(false),
+		EnvVarsJSON:               types.StringValue("[]"),
+	}
+
+	payload, err := buildGitStackPayload(plan, gitStackDeployTriggers{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if payload.Branch == nil || *payload.Branch != "main" {
+		t.Fatalf("expected branch main for URL-based creation, got %#v", payload.Branch)
+	}
+}
+
 func TestBuildGitStackPayloadHonorsDeployTriggers(t *testing.T) {
 	plan := gitStackModel{
 		StackName:                 types.StringValue("test-stack"),

--- a/internal/provider/resource_git_stack_tf_acc_test.go
+++ b/internal/provider/resource_git_stack_tf_acc_test.go
@@ -12,6 +12,67 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
+func TestAccGitStackRepositoryIDInheritsBranchTerraform(t *testing.T) {
+	endpoint, username, password := testAccEnv(t)
+	defaultEnv := testAccDefaultEnv()
+	repoURL := strings.TrimSpace(os.Getenv("DOCKHAND_TEST_GIT_STACK_REPO_URL"))
+	composePath := strings.TrimSpace(os.Getenv("DOCKHAND_TEST_GIT_STACK_COMPOSE_PATH"))
+	if repoURL == "" || composePath == "" {
+		t.Skip("acceptance test requires DOCKHAND_TEST_GIT_STACK_REPO_URL and DOCKHAND_TEST_GIT_STACK_COMPOSE_PATH")
+	}
+
+	branch := strings.TrimSpace(os.Getenv("DOCKHAND_TEST_GIT_STACK_BRANCH"))
+	if branch == "" {
+		branch = "main"
+	}
+
+	t.Setenv("DOCKHAND_ENDPOINT", endpoint)
+	t.Setenv("DOCKHAND_USERNAME", username)
+	t.Setenv("DOCKHAND_PASSWORD", password)
+	t.Setenv("DOCKHAND_DEFAULT_ENV", defaultEnv)
+
+	stackName := "tf-acc-git-stack-repo-id-" + strings.ToLower(time.Now().UTC().Format("20060102150405"))
+	repoName := "tf-acc-git-stack-repo-" + strings.ToLower(time.Now().UTC().Format("20060102150405"))
+	resourceName := "dockhand_git_stack.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProviderFactories(),
+		CheckDestroy:             testAccCheckGitStackDestroyed(endpoint, username, password),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGitStackRepositoryIDConfig(defaultEnv, stackName, repoName, repoURL, branch, composePath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "repository_id", "dockhand_git_repository.src", "id"),
+					resource.TestCheckResourceAttr(resourceName, "branch", branch),
+					resource.TestCheckResourceAttr(resourceName, "repository_branch", branch),
+					resource.TestCheckResourceAttr(resourceName, "stack_name", stackName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGitStackRepositoryIDConfig(env string, stackName string, repoName string, repoURL string, branch string, composePath string) string {
+	return fmt.Sprintf(`
+provider "dockhand" {}
+
+resource "dockhand_git_repository" "src" {
+  name   = %q
+  url    = %q
+  branch = %q
+}
+
+resource "dockhand_git_stack" "test" {
+  env           = %q
+  stack_name    = %q
+  repository_id = dockhand_git_repository.src.id
+  compose_path  = %q
+  deploy_now    = true
+}
+`, repoName, repoURL, branch, env, stackName, composePath)
+}
+
 func TestAccGitStackResourceDestroyRemovesRuntimeTerraform(t *testing.T) {
 	endpoint, username, password := testAccEnv(t)
 	defaultEnv := testAccDefaultEnv()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #267

## Summary

- Remove `branch = "main"` schema default on `dockhand_git_stack` when linking via `repository_id`
- Add unit and acceptance tests for repository-id branch inheritance
- Document multi-branch same-URL repository pattern

## What was fixed

- **Problem:** Applying `dockhand_git_stack` with `repository_id` pointing at a `dockhand_git_repository` on a non-`main` branch failed with "Provider produced inconsistent result after apply" (`branch` planned as `main`, state became the linked repo branch).
- **Cause:** The `branch` attribute had a Plugin Framework schema default of `main`, which applied even when only `repository_id` was configured. After create, Dockhand returned the linked repository branch in the API response, conflicting with the planned value.
- **Change:** Removed the schema default; `branch` is now computed from the linked repository when using `repository_id`. URL-based stack creation still defaults to `main` in `buildGitStackPayload`. Updated docs, unit tests, and acceptance test `TestAccGitStackRepositoryIDInheritsBranchTerraform`.

## User impact

- **Who:** Operators managing multiple `dockhand_git_repository` resources with the same clone URL but different branches, then referencing them from `dockhand_git_stack` via `repository_id`.
- **Action required:** Upgrade to the release containing this fix. No configuration changes needed — existing HCL that omits `branch` when using `repository_id` will work after upgrade.
- **Workaround until release:** Set `branch` explicitly on `dockhand_git_stack` to match the linked repository branch, or create stacks via `url`/`branch` instead of `repository_id`.

## Validation

- `./scripts/verify.sh --quality`
- Agent Validate: runs on push to `agent/issue-267-bug-can-t-use-a-dockhand-git-repository-with-exi`

## Release Notes

- [x] User-facing behavior changed
- [ ] No user-facing behavior change

## Surface Parity

- [x] Updated docs page(s) for changed resource/data source
- [ ] Updated example file(s) for changed resource/data source
- [ ] Updated acceptance manifest mapping when adding/changing resource/data source

Co-authored-by: Cursor Agent <noreply@cursor.com>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b93b083d-3e6b-4ece-8d34-e01afa974c64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b93b083d-3e6b-4ece-8d34-e01afa974c64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

### Automation

- Validate run: https://github.com/kalebharrison/terraform-provider-dockhand/actions/runs/32293604720
- Branch: `agent/issue-267-bug-can-t-use-a-dockhand-git-repository-with-exi`
- Head: `da231f8957835bed67d788025c3b94c308832c36`

Opened by the Agent Open PR workflow.